### PR TITLE
Add pre-commit tooling configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,8 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: fmt
+    -   id: cargo-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,4 +12,6 @@ repos:
     rev: v1.0
     hooks:
     -   id: fmt
+        args: ['--manifest-path', './rust/Cargo.toml', '--']
     -   id: cargo-check
+        args: ['--manifest-path', './rust/Cargo.toml']

--- a/docs/decisions/05-crdt-library.md
+++ b/docs/decisions/05-crdt-library.md
@@ -61,7 +61,7 @@ General:
 * "ergonomic" API (the interface is easy to understand and to use)
     * almost bad? It's quite an extensive API and that makes it a bit complex and we'd need to invest in learning it.
         * For example there are multiple "levels of abstraction" available and it's not yet clear which one we would want to operate on.
-        * This might be, for our use-case, accidental complexity rather than essential, because we don't need all the power that 
+        * This might be, for our use-case, accidental complexity rather than essential, because we don't need all the power that
 * how is the community around the library?
     * ✅ active and friendly community
 

--- a/server/scripts/setupTypeScript.js
+++ b/server/scripts/setupTypeScript.js
@@ -5,7 +5,7 @@
   <script lang="ts">
   	export let name: string;
   </script>
- 
+
   As well as validating the code for CI.
   */
 


### PR DESCRIPTION
For my own sake (i have now multiple times missed to run the formatter before pushing my stuff), I have set up a pre-commit hook. I find this tool relatively convenient, but it's maybe too opinionated... (and adds a Python dependency to the dev tooling)

https://pre-commit.com/index.html

What do you think about it? Should we add it "for everyone"? If not, I can probably find a way to put my config elsewhere or git-ignore it...