### PR TITLE
Clean up Vim plugin code

### DIFF
--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -261,7 +261,7 @@ pub mod tests {
             let mut cmd = tokio::process::Command::new("nvim");
             cmd.arg("--headless").arg("--embed");
             let (nvim, _, _) = new_child_cmd(&mut cmd, handler).await.unwrap();
-            nvim.command("Ethersync")
+            nvim.command("EthersyncInfo")
                 .await
                 .expect("Failed to run Ethersync");
         });

--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -49,14 +49,6 @@ impl Neovim {
             .expect("Failed to send input to Neovim");
     }
 
-    // TODO: The "Etherbonk" approach is not a very good way of picking different sockets...
-    pub async fn etherbonk(&mut self) {
-        self.nvim
-            .command("Etherbonk")
-            .await
-            .expect("Running Etherbonk failed");
-    }
-
     #[allow(dead_code)]
     async fn new_ethersync_enabled(initial_content: &str) -> (Self, PathBuf) {
         let dir = TempDir::new().unwrap();

--- a/daemon/src/bin/fuzzer.rs
+++ b/daemon/src/bin/fuzzer.rs
@@ -52,8 +52,8 @@ async fn main() {
         file2.as_path(),
     );
 
-    let mut nvim2 = Neovim::new(file2).await;
-    nvim2.etherbonk().await;
+    std::env::set_var("ETHERSYNC_SOCKET", "/tmp/etherbonk");
+    let nvim2 = Neovim::new(file2).await;
 
     let mut actors: HashMap<String, Box<dyn Actor>> = HashMap::new();
     actors.insert("daemon".to_string(), Box::new(daemon));

--- a/daemon/src/client.rs
+++ b/daemon/src/client.rs
@@ -23,6 +23,8 @@ pub fn connection(socket_path: &Path) {
             print!("Content-Length: {length}\r\n\r\n{line}");
             std::io::stdout().flush().expect("Failed to flush stdout");
         }
+        // Socket has been closed, so exit the process.
+        std::process::exit(1);
     });
 
     let mut data = vec![];
@@ -54,4 +56,5 @@ pub fn connection(socket_path: &Path) {
             reading_header = true;
         }
     }
+    // Stdin has been closed, so exit the process.
 }

--- a/vim-plugin/lua/changetracker.lua
+++ b/vim-plugin/lua/changetracker.lua
@@ -10,7 +10,7 @@ local prev_lines
 -- Used to note that changes to the buffer should be ignored, and not be sent out as deltas.
 local ignore_edits = false
 
-local function debug(tbl)
+local function debug(_tbl) --[[ @diagnostic disable-line ]]
     -- TODO: re-implement this somehow, using print?
 end
 

--- a/vim-plugin/lua/changetracker.lua
+++ b/vim-plugin/lua/changetracker.lua
@@ -14,6 +14,9 @@ local function debug(_tbl) --[[ @diagnostic disable-line ]]
     -- TODO: re-implement this somehow, using print?
 end
 
+-- Subscribes the callback to changes for a given buffer id and reports with a delta.
+--
+-- The delta can be expected to be in the format as specified in the daemon-editor protocol.
 function M.trackChanges(buffer, callback)
     prev_lines = vim.api.nvim_buf_get_lines(buffer, 0, -1, true)
 

--- a/vim-plugin/lua/changetracker.lua
+++ b/vim-plugin/lua/changetracker.lua
@@ -1,0 +1,110 @@
+local sync = require("vim.lsp.sync")
+local utils = require("utils")
+
+local M = {}
+
+-- Used to remember the previous content of the buffer, so that we can
+-- calculate the difference between the previous and the current content.
+local prev_lines
+
+-- Used to note that changes to the buffer should be ignored, and not be sent out as deltas.
+local ignore_edits = false
+
+local function debug(tbl)
+    -- TODO: re-implement this somehow, using print?
+end
+
+function M.trackChanges(buffer, callback)
+    prev_lines = vim.api.nvim_buf_get_lines(buffer, 0, -1, true)
+
+    vim.api.nvim_buf_attach(buffer, false, {
+        on_lines = function(
+            _the_literal_string_lines --[[@diagnostic disable-line]],
+            _buffer_handle --[[@diagnostic disable-line]],
+            _changedtick, --[[@diagnostic disable-line]]
+            first_line,
+            last_line,
+            new_last_line
+        )
+            -- Line counts that we get called with are zero-based.
+            -- last_line and new_last_line are exclusive
+
+            debug({ first_line = first_line, last_line = last_line, new_last_line = new_last_line })
+            -- TODO: optimize with a cache
+            local curr_lines = vim.api.nvim_buf_get_lines(buffer, 0, -1, true)
+
+            -- Are we currently ignoring edits?
+            if ignore_edits then
+                prev_lines = curr_lines
+                return
+            end
+
+            debug({ curr_lines = curr_lines, prev_lines = prev_lines })
+            local diff = sync.compute_diff(prev_lines, curr_lines, first_line, last_line, new_last_line, "utf-32", "\n")
+            -- line/character indices in diff are zero-based.
+            debug({ diff = diff })
+
+            -- Sometimes, Vim deletes full lines by deleting the last line, plus an imaginary newline at the end. For example, to delete the second line, Vim would delete from (line: 1, column: 0) to (line: 2, column 0).
+            -- But, in the case of deleting the last line, what we expect in the rest of Ethersync is to delete the newline *before* the line.
+            -- So let's change the deleted range to (line: 0, column: [last character of the first line]) to (line: 1, column: [last character of the second line]).
+
+            if diff.range["end"].line == #prev_lines then
+                -- Range spans to a line one after the visible buffer lines.
+                if diff.range["start"].line == 0 then
+                    -- The range starts on the first line, so we can't "shift the range backwards".
+                    -- Instead, we just shorten the range by one character.
+                    diff.range["end"].line = diff.range["end"].line - 1
+                    diff.range["end"].character = vim.fn.strchars(prev_lines[#prev_lines])
+                    if string.sub(diff.text, vim.fn.strchars(diff.text)) == "\n" then
+                        -- The replacement ends with a newline.
+                        -- Drop it, because we shortened the range not to include the newline.
+                        diff.text = string.sub(diff.text, 1, -2)
+                    end
+                else
+                    -- The range doesn't start on the first line.
+                    if diff.range["start"].character == 0 then
+                        -- Operation applies to beginning of line, that means it's possible to shift it back.
+                        -- Modify edit, s.t. not the last \n, but the one before is replaced.
+                        diff.range["start"].line = diff.range["start"].line - 1
+                        diff.range["end"].line = diff.range["end"].line - 1
+                        diff.range["start"].character = vim.fn.strchars(prev_lines[diff.range["start"].line + 1], false)
+                        diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1], false)
+                    end
+                end
+            end
+
+            prev_lines = curr_lines
+
+            local delta = {
+                {
+                    range = {
+                        anchor = diff.range.start,
+                        head = diff.range["end"],
+                    },
+                    replacement = diff.text,
+                },
+            }
+            callback(delta)
+        end,
+    })
+end
+
+function M.applyDelta(buffer, delta)
+    local text_edits = {}
+    for _, replacement in ipairs(delta) do
+        local text_edit = {
+            range = {
+                start = replacement.range.anchor,
+                ["end"] = replacement.range.head,
+            },
+            newText = replacement.replacement,
+        }
+        table.insert(text_edits, text_edit)
+    end
+
+    ignore_edits = true
+    utils.apply_text_edits(text_edits, buffer, "utf-32")
+    ignore_edits = false
+end
+
+return M

--- a/vim-plugin/lua/utils.lua
+++ b/vim-plugin/lua/utils.lua
@@ -1,5 +1,11 @@
 local M = {}
 
+function M.debug(tbl)
+    if true then
+        --client.notify("debug", tbl)
+    end
+end
+
 function M.appendNewline()
     print("Appending newline...")
     vim.cmd("normal! Go")

--- a/vim-plugin/lua/utils.lua
+++ b/vim-plugin/lua/utils.lua
@@ -180,23 +180,4 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
     --end
 end
 
--- TEST SUITE
-
-local function assertEqual(left, right)
-    assert(left == right, "not equal: " .. tostring(left) .. " != " .. tostring(right))
-end
-
-local function assertFail(call)
-    local status, _ = pcall(call)
-    assert(not status, "Call did not fail, although it should have.")
-end
-
-function M.testAllUnits()
-    assertEqual(2 + 2, 4)
-    assertFail(function()
-        error("This should fail.")
-    end)
-    print("Ethersync tests successful!")
-end
-
 return M

--- a/vim-plugin/lua/utils.lua
+++ b/vim-plugin/lua/utils.lua
@@ -1,11 +1,5 @@
 local M = {}
 
-function M.debug(tbl)
-    if true then
-        --client.notify("debug", tbl)
-    end
-end
-
 function M.appendNewline()
     print("Appending newline...")
     vim.cmd("normal! Go")

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -53,13 +53,16 @@ local function disconnect()
 end
 
 -- Connect to the daemon.
-local function connect(socket_path)
+local function connect()
     disconnect()
 
     local params = { "client" }
+
+    local socket_path = os.getenv("ETHERSYNC_SOCKET")
     if socket_path then
         table.insert(params, "--socket-path=" .. socket_path)
     end
+
     client = vim.lsp.rpc.start("ethersync", params, {
         notification = function(method, notification_params)
             processOperationForEditor(method, notification_params)
@@ -147,6 +150,3 @@ end
 
 vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, { callback = EthersyncOpenBuffer })
 vim.api.nvim_create_autocmd("BufUnload", { callback = EthersyncCloseBuffer })
-vim.api.nvim_create_user_command("Etherbonk", function()
-    connect("/tmp/etherbonk")
-end, {})

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -103,7 +103,6 @@ function EthersyncOpenBuffer()
         theFile = vim.fn.expand("%:p")
         vim.bo.modifiable = false
         connect()
-        print("Ethersync activated for file " .. theFile)
     end
 
     if theFile ~= vim.fn.expand("%:p") then
@@ -148,5 +147,18 @@ function EthersyncCloseBuffer()
     sendNotification("close", { uri = uri })
 end
 
+function EthersyncInfo()
+    if client then
+        print("Connected to Ethersync daemon!")
+        print("File: " .. theFile)
+        print("Editor revision: " .. editorRevision)
+        print("Daemon revision: " .. daemonRevision)
+    else
+        print("Not connected to Ethersync daemon.")
+    end
+end
+
 vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, { callback = EthersyncOpenBuffer })
 vim.api.nvim_create_autocmd("BufUnload", { callback = EthersyncCloseBuffer })
+
+vim.api.nvim_create_user_command("EthersyncInfo", EthersyncInfo, {})

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -1,4 +1,3 @@
-local utils = require("utils")
 local changetracker = require("changetracker")
 
 -- JSON-RPC connection.
@@ -168,7 +167,6 @@ end
 vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, { callback = EthersyncOpenBuffer })
 vim.api.nvim_create_autocmd("BufUnload", { callback = EthersyncCloseBuffer })
 
-vim.api.nvim_create_user_command("EthersyncRunTests", utils.testAllUnits, {})
 vim.api.nvim_create_user_command("EthersyncGoOffline", goOffline, {})
 vim.api.nvim_create_user_command("EthersyncGoOnline", goOnline, {})
 vim.api.nvim_create_user_command("EthersyncReload", resetState, {})


### PR DESCRIPTION
This mainly pulls out the delta input/output logic into a helper file, removes unused/untested code, and adds the possibility to configure the socket via the `ETHERSYNC_SOCKET` environment variable.

This breaks our debug() in Vim, because the changetracker file doesn't have access to the `client`. It always was a bit weird anyway – maybe we should write it to a file, like [Vim's LSP feature does](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/lsp/log.lua)?