### PR TITLE
Add logging to nvim plugin

### DIFF
--- a/vim-plugin/lua/dlog.lua
+++ b/vim-plugin/lua/dlog.lua
@@ -22,6 +22,11 @@ local function noop(_) end
 ---@return fun(msg: string, ...): any logger function
 function M.logger(logger_name)
     if has_debuglog then
+        debuglog.enable("*")
+        debuglog.set_config({
+            log_to_file = true,
+            log_to_console = false,
+        })
         return debuglog.logger_for_shim_only(logger_name)
     end
     return noop

--- a/vim-plugin/lua/dlog.lua
+++ b/vim-plugin/lua/dlog.lua
@@ -1,0 +1,40 @@
+---dlog is a module for writing debug logs.
+---
+---WARNING: This file is auto-generated, DO NOT MODIFY.
+---
+---Example usage:
+---  local d = require("dlog").logger("my_logger")
+---  d("Formatted lua string %s, number %d, etc", "test", 42)
+---
+---This will print "Formatted lua string test, number 42, etc"
+---
+---If debuglog plugin is not installed, all logs are no-op.
+---Read more at https://github.com/smartpde/debuglog#shim
+local has_debuglog, debuglog = pcall(require, "debuglog")
+
+local M = {}
+
+local function noop(_) end
+
+---Returns the logger object if the debuglog plugin installed, or a
+---no-op function otherwise.
+---@param logger_name string the name of the logger
+---@return fun(msg: string, ...): any logger function
+function M.logger(logger_name)
+    if has_debuglog then
+        return debuglog.logger_for_shim_only(logger_name)
+    end
+    return noop
+end
+
+---Checks if the logger is enabled.
+---@param logger_name string the name of the logger
+---@return boolean enabled whether the logger is enabled
+function M.is_enabled(logger_name)
+    if has_debuglog then
+        return debuglog.is_enabled(logger_name)
+    end
+    return false
+end
+
+return M

--- a/vim-plugin/lua/logging.lua
+++ b/vim-plugin/lua/logging.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+M.log_file_handle = io.open("/tmp/ethersync-nvim.log", "a")
+
+function M.debug(...)
+    local objects = {}
+    for i = 1, select("#", ...) do
+        local v = select(i, ...)
+        table.insert(objects, vim.inspect(v))
+    end
+    M.log_file_handle:write(table.concat(objects, "\n") .. "\n")
+    M.log_file_handle:flush()
+end
+
+return M

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -1,4 +1,5 @@
 local changetracker = require("changetracker")
+local logging = require("logging")
 
 -- JSON-RPC connection.
 local client
@@ -41,6 +42,7 @@ end
 
 -- Connect to the daemon.
 local function connect()
+    logging.debug("Connect called, testing logging. Please check /tmp/ethersync-nvim.log :)")
     if client then
         client.terminate()
         local buffer = vim.uri_to_bufnr("file://" .. theFile)

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -1,5 +1,7 @@
 local changetracker = require("changetracker")
 local logging = require("logging")
+local dlog = require("dlog")
+local logger = dlog.logger("some_logger")
 
 -- JSON-RPC connection.
 local client
@@ -43,6 +45,8 @@ end
 -- Connect to the daemon.
 local function connect()
     logging.debug("Connect called, testing logging. Please check /tmp/ethersync-nvim.log :)")
+    logger("This is another way to log stuff, but introduces the debuglog dependency.")
+    logger("Seems a bit more nice out of the box")
     if client then
         client.terminate()
         local buffer = vim.uri_to_bufnr("file://" .. theFile)


### PR DESCRIPTION
This is WIP.

Currently I see two ways to do logging:
- roll it ourselves quick & dirty and just write stuff to a file with io
- use another plugin / package to do it

I have found https://github.com/smartpde/debuglog, which doesn't seem too bad. Maybe there are better ones, I haven't done the full research.

This branch currently shows both options in a proof of concept way.

To enable the logging via plugin, you'll need to install debuglog, e.g. like this for Lazy:

```lua
return {
  {
    "smartpde/debuglog",
    config = function()
      require("debuglog").setup({})
    end,
  },
}
```