### PR TITLE
Enable ethersync to work with multiple files

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -81,6 +81,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +410,7 @@ name = "ethersync"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
  "automerge",
  "clap",

--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "walkdir",
 ]
 
 [[package]]
@@ -1319,6 +1320,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,6 +1854,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1899,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -81,6 +81,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
+name = "assert_fs"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "bitmaps"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +183,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -269,6 +300,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +442,12 @@ dependencies = [
  "socket2 0.4.10",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -406,10 +474,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ethersync"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "assert_fs",
  "assert_matches",
  "async-trait",
  "automerge",
@@ -435,6 +514,12 @@ dependencies = [
  "tracing-test",
  "walkdir",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flate2"
@@ -606,6 +691,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.5.0",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +837,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.6",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "im"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +928,12 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "local-ip-address"
@@ -1092,6 +1223,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,7 +1394,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1319,6 +1477,19 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ryu"
@@ -1500,6 +1671,24 @@ name = "temp-dir"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -81,21 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
-name = "assert_fs"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
-dependencies = [
- "anstyle",
- "doc-comment",
- "globwalk",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "tempfile",
-]
-
-[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,12 +147,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
-
-[[package]]
 name = "bitmaps"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,16 +162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bstr"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -300,31 +269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,12 +360,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,12 +380,6 @@ dependencies = [
  "socket2 0.4.10",
  "winapi",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -474,21 +406,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ethersync"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "assert_fs",
  "assert_matches",
  "async-trait",
  "automerge",
@@ -514,12 +435,6 @@ dependencies = [
  "tracing-test",
  "walkdir",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flate2"
@@ -691,30 +606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "globset"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags 2.5.0",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,22 +728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ignore"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata 0.4.6",
- "same-file",
- "walkdir",
- "winapi-util",
-]
-
-[[package]]
 name = "im"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,12 +803,6 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "local-ip-address"
@@ -1223,33 +1092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "predicates"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
-dependencies = [
- "anstyle",
- "difflib",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,7 +1236,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -1477,19 +1319,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustix"
-version = "0.38.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
-dependencies = [
- "bitflags 2.5.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "ryu"
@@ -1671,24 +1500,6 @@ name = "temp-dir"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
-
-[[package]]
-name = "tempfile"
-version = "3.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
-dependencies = [
- "cfg-if",
- "fastrand",
- "rustix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -33,6 +33,7 @@ walkdir = "2.5.0"
 
 [dev-dependencies]
 assert_matches = "1.5"
+assert_fs = "1.1.1"
 
 
 [profile.release]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -33,7 +33,6 @@ walkdir = "2.5.0"
 
 [dev-dependencies]
 assert_matches = "1.5"
-assert_fs = "1.1.1"
 
 
 [profile.release]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -29,6 +29,7 @@ time-macros = { version = "0.2.0-alpha.1" }
 local-ip-address = "0.6.1"
 public-ip = "0.2.2"
 tokio-util = "0.7.11"
+walkdir = "2.5.0"
 
 [features]
 simulate_edits_from_editor = []

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -16,7 +16,7 @@ operational-transform = "0.6.1"
 anyhow = "1.0.81"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["local-time"] }
-nvim-rs = {version = "0.7.0", features = ["use_tokio"]}
+nvim-rs = { version = "0.7.0", features = ["use_tokio"] }
 temp-dir = "0.1.13"
 async-trait = "0.1.79"
 pretty_assertions = "1.4.0"
@@ -31,9 +31,9 @@ public-ip = "0.2.2"
 tokio-util = "0.7.11"
 walkdir = "2.5.0"
 
-[features]
-simulate_edits_from_editor = []
-simulate_edits_on_crdt = []
+[dev-dependencies]
+assert_matches = "1.5"
+
 
 [profile.release]
 debug = true

--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -28,6 +28,9 @@ pub struct Neovim {
 }
 
 impl Neovim {
+    /// # Panics
+    ///
+    /// Will panic if Neovim cannot be started or if the file cannot be opened.
     pub async fn new(file_path: PathBuf) -> Self {
         let handler = Dummy::new();
         let mut cmd = tokio::process::Command::new("nvim");
@@ -42,6 +45,9 @@ impl Neovim {
         Self { nvim, buffer }
     }
 
+    /// # Panics
+    ///
+    /// Will panic if input cannot be sent to Neovim.
     pub async fn input(&mut self, input: &str) {
         self.nvim
             .input(input)
@@ -84,7 +90,7 @@ impl Actor for Neovim {
             "🥕".to_string(),
             "\n".to_string(),
         ];
-        let s = random_string(rand_usize_inclusive(1, 5), string_components);
+        let s = random_string(rand_usize_inclusive(1, 5), &string_components);
 
         let components = vec![
             "h".to_string(),
@@ -109,7 +115,7 @@ impl Actor for Neovim {
             format!("I{}", s),
         ];
 
-        vim_normal_command.push_str(&random_string(rand_usize_inclusive(1, 2), components));
+        vim_normal_command.push_str(&random_string(rand_usize_inclusive(1, 2), &components));
 
         self.nvim
             .command(&format!(r#"silent! execute "normal {vim_normal_command}""#))
@@ -147,7 +153,7 @@ impl Actor for Neovim {
     }*/
 }
 
-fn random_string(length: usize, components: Vec<String>) -> String {
+fn random_string(length: usize, components: &[String]) -> String {
     (0..length)
         .map(|_| components[rand_usize_inclusive(0, components.len() - 1)].clone())
         .collect::<String>()
@@ -169,7 +175,7 @@ struct MockSocket {
 
 #[allow(dead_code)]
 impl MockSocket {
-    async fn new(socket_path: &str, ignore_reads: bool) -> Self {
+    fn new(socket_path: &str, ignore_reads: bool) -> Self {
         if Path::new(socket_path).exists() {
             fs::remove_file(socket_path).expect("Could not remove existing socket file");
         }
@@ -226,19 +232,12 @@ impl MockSocket {
     }
 
     async fn recv(&mut self) -> JSONValue {
-        loop {
-            let line = self
-                .reader_rx
-                .recv()
-                .await
-                .expect("Could not receive message");
-            let json: JSONValue = serde_json::from_str(&line).expect("Could not parse JSON");
-            if json["method"] == "debug" {
-                continue;
-            } else {
-                return json;
-            }
-        }
+        let line = self
+            .reader_rx
+            .recv()
+            .await
+            .expect("Could not receive message");
+        serde_json::from_str(&line).expect("Could not parse JSON")
     }
 }
 
@@ -277,7 +276,7 @@ pub mod tests {
     ) {
         let runtime = Runtime::new().expect("Could not create Tokio runtime");
         runtime.block_on(async {
-            let mut socket = MockSocket::new("/tmp/ethersync", true).await;
+            let mut socket = MockSocket::new("/tmp/ethersync", true);
             let (nvim, file_path) = Neovim::new_ethersync_enabled(initial_content).await;
 
             for op in &deltas {
@@ -345,7 +344,7 @@ pub mod tests {
         let runtime = Runtime::new().expect("Could not create Tokio runtime");
         runtime.block_on(async {
             timeout(Duration::from_millis(5000), async {
-                let mut socket = MockSocket::new("/tmp/ethersync", false).await;
+                let mut socket = MockSocket::new("/tmp/ethersync", false);
                 let (mut nvim, _file_path) = Neovim::new_ethersync_enabled(initial_content).await;
 
                 let msg = socket.recv().await;

--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -506,7 +506,18 @@ pub mod tests {
         assert_vim_input_yields_replacements("ä", "dd", vec![replace_ed((0, 0), (0, 1), "")]);
 
         assert_vim_input_yields_replacements("a\n", "yyp", vec![replace_ed((0, 1), (0, 1), "\na")]);
+        assert_vim_input_yields_replacements(
+            "🥕\n",
+            "yyp",
+            vec![replace_ed((0, 1), (0, 1), "\n🥕")],
+        );
         assert_vim_input_yields_replacements("a", "yyp", vec![replace_ed((0, 1), (0, 1), "\na")]);
+
+        assert_vim_input_yields_replacements(
+            "a\n🥕\n",
+            "jyyp",
+            vec![replace_ed((1, 1), (1, 1), "\n🥕")],
+        );
 
         assert_vim_input_yields_replacements("a", "o", vec![replace_ed((0, 1), (0, 1), "\n")]);
 

--- a/daemon/src/connect.rs
+++ b/daemon/src/connect.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use tokio::net::{TcpListener, TcpStream, UnixListener};
 use tokio::time::{timeout, Duration};
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 use crate::daemon::DocumentActorHandle;
 use crate::editor::spawn_editor_connection;
@@ -15,11 +15,15 @@ pub struct PeerConnectionInfo {
     peer: Option<String>,
 }
 impl PeerConnectionInfo {
+    #[must_use]
     pub fn new(port: Option<u16>, peer: Option<String>) -> Self {
         Self { port, peer }
     }
 }
 
+/// # Panics
+///
+/// Will panic if we fail to dial the peer, of if we fail to accept incoming connections.
 pub async fn make_peer_connection(
     connection_info: PeerConnectionInfo,
     document_handle: DocumentActorHandle,
@@ -38,6 +42,9 @@ pub async fn make_peer_connection(
     }
 }
 
+/// # Panics
+///
+/// Will panic if we fail to listen on the socket, or if we fail to accept an incoming connection.
 pub async fn make_editor_connection(socket_path: PathBuf, document_handle: DocumentActorHandle) {
     if Path::new(&socket_path).exists() {
         fs::remove_file(&socket_path).expect("Could not remove/re-initialize socket");
@@ -46,7 +53,7 @@ pub async fn make_editor_connection(socket_path: PathBuf, document_handle: Docum
     match result {
         Ok(()) => {}
         Err(err) => {
-            error!("Failed to make editor connection: {err}");
+            panic!("Failed to make editor connection: {err}");
         }
     }
 }
@@ -73,7 +80,7 @@ async fn connect_with_peer(
 ) -> Result<(), io::Error> {
     let stream = TcpStream::connect(address).await?;
     info!("Connected to Peer.");
-    spawn_peer_sync(stream, document_handle);
+    spawn_peer_sync(stream, &document_handle);
     Ok(())
 }
 
@@ -81,7 +88,7 @@ async fn accept_peer_loop(
     port: u16,
     document_handle: DocumentActorHandle,
 ) -> Result<(), io::Error> {
-    let listener = TcpListener::bind(format!("0.0.0.0:{}", port)).await?;
+    let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
 
     if let Ok(ip) = local_ip() {
         info!("Listening on local TCP: {}:{}", ip, port);
@@ -89,7 +96,7 @@ async fn accept_peer_loop(
 
     timeout(Duration::from_secs(1), async {
         if let Some(ip) = public_ip::addr().await {
-            info!("Listening on public TCP: {}:{}", ip, port);
+            info!("Listening on public TCP: {ip}:{port}");
         }
     })
     .await
@@ -100,6 +107,6 @@ async fn accept_peer_loop(
     loop {
         let (stream, _addr) = listener.accept().await?;
         info!("Peer dialed us.");
-        spawn_peer_sync(stream, document_handle.clone());
+        spawn_peer_sync(stream, &document_handle);
     }
 }

--- a/daemon/src/connect.rs
+++ b/daemon/src/connect.rs
@@ -67,7 +67,7 @@ async fn accept_editor_loop(
 
     loop {
         let (stream, _addr) = listener.accept().await?;
-        info!("Client connection established.");
+        info!("Editor connection established");
 
         // TODO: we need to get rid of this await to accept multiple editors.
         spawn_editor_connection(stream, document_handle.clone()).await;

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -871,5 +871,48 @@ mod tests {
             dir.child("file2").assert("content2");
             dir.child("sub/file3").assert("content3");
         }
+
+        #[test]
+        #[should_panic]
+        fn test_file_path_for_uri_fails_not_absolute() {
+            let dir = setup_filesystem_for_testing();
+            let actor = DocumentActor::setup_for_testing(dir.path().to_path_buf());
+
+            actor.file_path_for_uri("this/is/absolutely/not/absolute");
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_file_path_for_uri_fails_not_within_base_dir() {
+            let dir = setup_filesystem_for_testing();
+            let actor = DocumentActor::setup_for_testing(dir.path().to_path_buf());
+
+            actor.file_path_for_uri("/this/is/not/the/base_dir/file");
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_file_path_for_uri_fails_only_base_dir() {
+            let dir = setup_filesystem_for_testing();
+            let actor = DocumentActor::setup_for_testing(dir.path().to_path_buf());
+
+            actor.file_path_for_uri(&format!("{}", dir.path().display()));
+        }
+
+        #[test]
+        fn test_file_path_for_uri_works() {
+            let dir = setup_filesystem_for_testing();
+            let actor = DocumentActor::setup_for_testing(dir.path().to_path_buf());
+
+            let file_paths = vec!["afile", "adir/with/some/file", "just/adir/"];
+            let prefix_options = vec!["file://", ""];
+            for prefix in prefix_options {
+                for &expected in &file_paths {
+                    let uri = format!("{}{}/{}", prefix, dir.path().display(), expected);
+
+                    assert_eq!(actor.file_path_for_uri(&uri), expected);
+                }
+            }
+        }
     }
 }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -206,7 +206,7 @@ impl DocumentActor {
                     .expect("Should have initialized text before performing random edit");
                 let ed_delta = EditorTextDelta::from_delta(delta.clone(), &text);
                 self.apply_delta_to_doc(&ed_delta, TEST_FILE_PATH);
-                self.process_crdt_file_deltas_in_ot(vec![FileTextDelta::new(
+                self.maybe_process_crdt_file_deltas_in_ot(vec![FileTextDelta::new(
                     TEST_FILE_PATH.to_string(),
                     delta,
                 )])
@@ -222,7 +222,7 @@ impl DocumentActor {
                 let file_deltas = FileTextDelta::from_crdt_patches(patches);
 
                 self.maybe_write_files_changed_in_file_deltas(&file_deltas);
-                self.process_crdt_file_deltas_in_ot(file_deltas).await;
+                self.maybe_process_crdt_file_deltas_in_ot(file_deltas).await;
 
                 response_tx
                     .send(peer_state)
@@ -377,7 +377,7 @@ impl DocumentActor {
         delta
     }
 
-    async fn process_crdt_file_deltas_in_ot(&mut self, file_deltas: Vec<FileTextDelta>) {
+    async fn maybe_process_crdt_file_deltas_in_ot(&mut self, file_deltas: Vec<FileTextDelta>) {
         for FileTextDelta { file_path, delta } in file_deltas {
             // Only process the CRDT delta, if editor has the file open.
             if let Some(ot_server) = self.ot_servers.get_mut(&file_path) {

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -247,12 +247,12 @@ impl DocumentActor {
         match message {
             EditorProtocolMessage::Open { uri } => {
                 let file_path = Self::file_path_for(&uri);
-                let ot_server = OTServer::new(
-                    self.current_file_content(&file_path)
-                        .unwrap_or_else(
-                            |_| panic!("Should have initialized key: {file_path} before initializing the document")
+                let ot_server =
+                    OTServer::new(self.current_file_content(&file_path).unwrap_or_else(|_| {
+                        panic!(
+                            "Could not open file {file_path}, because it doesn't exist in the CRDT"
                         )
-                );
+                    }));
                 self.ot_servers.insert(file_path, ot_server);
             }
             EditorProtocolMessage::Close { uri } => {

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -18,7 +18,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tracing::{debug, info, warn};
-use walkdir::{DirEntry, WalkDir};
+use walkdir::WalkDir;
 
 pub const TEST_FILE_PATH: &str = "text";
 
@@ -429,17 +429,9 @@ impl DocumentActor {
 
     /// Reading in the file is a preparatory step, before kicking off the actor.
     fn read_current_content_from_dir(&mut self) {
-        fn is_not_hidden(entry: &DirEntry) -> bool {
-            entry
-                .file_name()
-                .to_str()
-                .is_some_and(|s| entry.depth() == 0 || !s.starts_with('.'))
-        }
-
-        // TODO: Also filter out files ignored by .gitignore and such.
+        // TODO: Filter out files ignored by .gitignore and such.
         WalkDir::new(self.base_dir.clone())
             .into_iter()
-            .filter_entry(is_not_hidden)
             .filter_map(Result::ok)
             .filter(|metadata| metadata.file_type().is_file())
             .for_each(|file_path| {

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tracing::{debug, warn};
 
-const TEST_FILE_PATH: &str = "text";
+pub const TEST_FILE_PATH: &str = "text";
 
 // These messages are sent to the task that owns the document.
 pub enum DocMessage {

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -726,7 +726,7 @@ mod tests {
                 assert!(document.generate_sync_message(&mut state).is_none());
 
                 document.initialize_text("", "text");
-                // We have progressed out state, so update all peers about that.
+                // We have progressed our state, so update all peers about that.
                 assert!(document.generate_sync_message(&mut state).is_some());
                 // Again, stop, until peers tell us if they want more information.
                 assert!(document.generate_sync_message(&mut state).is_none());

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -219,7 +219,7 @@ impl DocumentActor {
                 response_tx,
             } => {
                 let patches = self.apply_sync_message_to_doc(message, &mut peer_state);
-                let file_deltas = Self::crdt_patches_to_file_deltas(patches);
+                let file_deltas = FileTextDelta::from_crdt_patches(patches);
 
                 self.maybe_write_files_changed_in_file_deltas(&file_deltas);
                 self.process_crdt_file_deltas_in_ot(file_deltas).await;
@@ -375,23 +375,6 @@ impl DocumentActor {
         delta.delete(deletion_length);
 
         delta
-    }
-
-    fn crdt_patches_to_file_deltas(patches: Vec<Patch>) -> Vec<FileTextDelta> {
-        let mut file_deltas: Vec<FileTextDelta> = vec![];
-
-        for patch in patches {
-            match patch.try_into() {
-                Ok(result) => {
-                    file_deltas.push(result);
-                }
-                Err(e) => {
-                    warn!("Failed to convert patch to delta: {:#?}", e);
-                }
-            }
-        }
-
-        file_deltas
     }
 
     async fn process_crdt_file_deltas_in_ot(&mut self, file_deltas: Vec<FileTextDelta>) {

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -271,13 +271,7 @@ impl DocumentActor {
             EditorProtocolMessage::Open { uri } => {
                 let file_path = self.file_path_for_uri(&uri);
                 debug!("Got an 'open' message for {file_path}");
-                let ot_server =
-                    OTServer::new(self.current_file_content(&file_path).unwrap_or_else(|_| {
-                        panic!(
-                            "Could not open file {file_path}, because it doesn't exist in the CRDT"
-                        )
-                    }));
-                self.ot_servers.insert(file_path, ot_server);
+                self.open_file_path(file_path);
             }
             EditorProtocolMessage::Close { uri } => {
                 let file_path = self.file_path_for_uri(&uri);
@@ -298,6 +292,13 @@ impl DocumentActor {
                     .await;
             }
         }
+    }
+
+    fn open_file_path(&mut self, file_path: String) {
+        let ot_server = OTServer::new(self.current_file_content(&file_path).unwrap_or_else(|_| {
+            panic!("Could not open file {file_path}, because it doesn't exist in the CRDT")
+        }));
+        self.ot_servers.insert(file_path, ot_server);
     }
 
     fn apply_sync_message_to_doc(

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -422,6 +422,13 @@ impl DocumentActor {
                 .expect("Failed to get file content when writing to disk. Key should have existed");
             let abs_path = self.absolute_path_for_file_path(file_path);
             debug!("Writing to {abs_path}.");
+
+            // Create the parent directorie(s), if neccessary.
+            let parent_dir = Path::new(&abs_path).parent().unwrap();
+            std::fs::create_dir_all(parent_dir).unwrap_or_else(|_| {
+                panic!("Could not create parent directory {}", parent_dir.display())
+            });
+
             std::fs::write(&abs_path, text)
                 .unwrap_or_else(|_| panic!("Could not write to file {abs_path}"));
         }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -914,5 +914,27 @@ mod tests {
                 }
             }
         }
+
+        #[test]
+        fn test_simulate_editor_edits() {
+            let dir = setup_filesystem_for_testing();
+            let mut actor = DocumentActor::setup_for_testing(dir.path().to_path_buf());
+            actor.read_current_content_from_dir();
+
+            let file_path = "file1".to_string();
+
+            actor.open_file_path(file_path.clone());
+
+            let delta = rev_ed_delta_single(0, (0, 0), (0, 0), "foobar");
+            let (editor_delta_for_crdt, rev_ed_text_deltas) =
+                actor.apply_delta_to_ot(delta, "file1");
+            actor.apply_delta_to_doc(&editor_delta_for_crdt, &file_path);
+
+            // Confirm nothing transformed needs to go to editor.
+            assert_eq!(rev_ed_text_deltas, vec![]);
+
+            // Confirm edit was applied.
+            actor.assert_file_content(&file_path, "foobarcontent1");
+        }
     }
 }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -125,6 +125,14 @@ impl Document {
 
     fn initialize_text(&mut self, text: &str, file_path: &str) {
         info!("Initializing {file_path} in CRDT");
+        if self.text_obj(file_path).is_ok() {
+            // While automerge accepts putting an object multiple times, in our current
+            // architecture this should not happen: Only the host should initialize every file
+            // once, while peers just take in whatever already exists.
+            //
+            // This might change in a future more peer to peer world.
+            panic!("It seems {file_path} was already initialized.");
+        }
         let text_obj = self
             .doc
             .put_object(automerge::ROOT, file_path, ObjType::Text)

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -5,7 +5,7 @@ use tokio::{
     sync::mpsc,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 use crate::daemon::{DocMessage, DocumentActorHandle};
 use crate::types::EditorProtocolMessage;
@@ -75,7 +75,7 @@ impl SocketReadActor {
         loop {
             match lines.next_line().await {
                 Ok(Some(line)) => {
-                    debug!("Got a line from the client: {:#?}", line);
+                    trace!("Got a line from the client: {:#?}", line);
                     let jsonrpc = EditorProtocolMessage::from_jsonrpc(&line)
                         .expect("Failed to parse JSON-RPC message");
                     self.document_handle
@@ -91,7 +91,7 @@ impl SocketReadActor {
             }
         }
         self.shutdown_token.cancel();
-        info!("Client disconnect.");
+        info!("Client disconnected");
     }
 }
 
@@ -115,11 +115,10 @@ impl SocketWriteActor {
     }
 
     async fn write_to_socket(&mut self, message: EditorProtocolMessage) {
-        debug!("Received editor message to send to it.");
         let payload = message
             .to_jsonrpc()
             .expect("Failed to serialize JSON-RPC message");
-        debug!("Sending message to editor: {:#?}", payload);
+        trace!("Sending message to editor: {:#?}", payload);
         self.writer
             .write_all(format!("{payload}\n").as_bytes())
             .await

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -97,8 +97,8 @@ impl SocketReadActor {
 
 pub struct SocketWriteActor {
     writer: WriteHalf<UnixStream>,
-    shutdown_token: CancellationToken,
     editor_message_receiver: EditorMessageReceiver,
+    shutdown_token: CancellationToken,
 }
 
 impl SocketWriteActor {
@@ -130,7 +130,7 @@ impl SocketWriteActor {
         // We're sending an editor message to the client.
         loop {
             tokio::select! {
-                _ = self.shutdown_token.cancelled() => {
+                () = self.shutdown_token.cancelled() => {
                     debug!("Shutting down JSON-RPC sender (due to socket disconnet)");
                     break;
                 }

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+#[macro_use]
+extern crate assert_matches;
+
 pub mod actors;
 pub mod connect;
 pub mod daemon;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -31,10 +31,11 @@ enum Commands {
         /// Port to listen on as a hosting peer.
         #[arg(short, long, default_value = "4242")]
         port: Option<u16>,
+        /// The directory to sync.
+        directory: Option<PathBuf>,
         /// IP + port of a peer to connect to. Example: 192.168.1.42:1234
+        #[arg(long)]
         peer: Option<String>,
-        #[arg(short, long)]
-        file: PathBuf,
     },
     /// Open a JSON-RPC connection to the Ethersync daemon on stdin/stdout.
     Client,
@@ -55,8 +56,15 @@ async fn main() -> io::Result<()> {
     let socket_path = cli.socket_path.unwrap_or(DEFAULT_SOCKET_PATH.into());
 
     match cli.command {
-        Commands::Daemon { port, peer, file } => {
-            Daemon::new(port, peer, &socket_path, &file);
+        Commands::Daemon {
+            port,
+            directory,
+            peer,
+        } => {
+            // TODO: directory should exist
+            let directory = directory
+                .unwrap_or(std::env::current_dir().expect("Could not access current directory"));
+            Daemon::new(port, peer, &socket_path, &directory);
             match signal::ctrl_c().await {
                 Ok(()) => {}
                 Err(err) => {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -4,6 +4,7 @@ use ethersync::logging;
 use std::io;
 use std::path::PathBuf;
 use tokio::signal;
+use tracing::info;
 
 mod jsonrpc_forwarder;
 
@@ -61,9 +62,11 @@ async fn main() -> io::Result<()> {
             directory,
             peer,
         } => {
-            // TODO: directory should exist
             let directory = directory
-                .unwrap_or(std::env::current_dir().expect("Could not access current directory"));
+                .unwrap_or(std::env::current_dir().expect("Could not access current directory"))
+                .canonicalize()
+                .expect("Could not access given directory");
+            info!("Starting Ethersync on {}", directory.display());
             Daemon::new(port, peer, &socket_path, &directory);
             match signal::ctrl_c().await {
                 Ok(()) => {}

--- a/daemon/src/ot.rs
+++ b/daemon/src/ot.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use crate::types::{EditorTextDelta, RevisionedEditorTextDelta, RevisionedTextDelta, TextDelta};
 use operational_transform::OperationSeq;
-use tracing::{debug, trace};
+use tracing::debug;
 
 ///    `OTServer` receives operations from both the CRDT world, and one editor and makes sure that
 ///    the editor operations (which might be based on an older document) are applicable to the
@@ -135,10 +135,9 @@ impl OTServer {
         );
         let confirmed_queue = self.editor_queue.drain(..seen_operations);
         for confirmed_editor_op in confirmed_queue {
-            trace!(
+            debug!(
                 "Applying confirmed operation {:#?} to last confirmed editor content {:?}",
-                &confirmed_editor_op,
-                &self.last_confirmed_editor_content
+                &confirmed_editor_op, &self.last_confirmed_editor_content
             );
             self.last_confirmed_editor_content = Self::force_apply(
                 &self.last_confirmed_editor_content,
@@ -151,10 +150,9 @@ impl OTServer {
         );
         op_seq = rev_delta.delta.into();
 
-        trace!(
+        debug!(
             "Applying incoming editor operation {:#?} to last confirmed editor content {:?}",
-            &op_seq,
-            &self.last_confirmed_editor_content
+            &op_seq, &self.last_confirmed_editor_content
         );
         self.last_confirmed_editor_content =
             Self::force_apply(&self.last_confirmed_editor_content, op_seq.clone());
@@ -163,7 +161,6 @@ impl OTServer {
         self.current_content = Self::force_apply(&self.current_content, op_seq.clone());
 
         let deltas_for_editor = self.deltas_for_editor();
-        debug!(for_editor = ?deltas_for_editor);
 
         (op_seq.into(), deltas_for_editor)
     }

--- a/daemon/src/ot.rs
+++ b/daemon/src/ot.rs
@@ -196,16 +196,13 @@ impl OTServer {
             op_seq.retain((doc_chars - op_seq.base_len()) as u64);
         }
         op_seq.apply(document).unwrap_or_else(|_| {
-            panic!(
-                "Could not apply operation {:?} to string with length {} ('{:?}')",
-                op_seq, doc_chars, document
-            )
+            panic!("Could not apply operation {op_seq:?} to string with length {doc_chars} ('{document:?}')")
         })
     }
 }
 
-/// This function takes operations t1 and m1 ... m_n,
-/// and returns operations t1' and m1' ... m_n'.
+/// This function takes operations t1 and m1 ... `m_n`,
+/// and returns operations t1' and m1' ... `m_n`'.
 /// .
 ///        t1
 ///     * ----> *

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -398,21 +398,21 @@ pub mod factories {
     use super::*;
 
     pub fn insert(at: usize, s: &str) -> TextDelta {
-        let mut delta: TextDelta = TextDelta::default();
+        let mut delta = TextDelta::default();
         delta.retain(at);
         delta.insert(s);
         delta
     }
 
     pub fn delete(from: usize, length: usize) -> TextDelta {
-        let mut delta: TextDelta = TextDelta::default();
+        let mut delta = TextDelta::default();
         delta.retain(from);
         delta.delete(length);
         delta
     }
 
     pub fn replace(from: usize, length: usize, s: &str) -> TextDelta {
-        let mut delta: TextDelta = TextDelta::default();
+        let mut delta = TextDelta::default();
         delta.retain(from);
         delta.delete(length);
         delta.insert(s);
@@ -505,21 +505,21 @@ mod tests {
     #[test]
     fn conversion_editor_to_text_delta_insert() {
         let ed_delta = ed_delta_single((0, 1), (0, 1), "a");
-        let delta: TextDelta = TextDelta::from_ed_delta(ed_delta, "foo");
+        let delta = TextDelta::from_ed_delta(ed_delta, "foo");
         assert_eq!(delta, insert(1, "a"));
     }
 
     #[test]
     fn conversion_editor_to_text_delta_delete() {
         let ed_delta = ed_delta_single((0, 0), (0, 1), "");
-        let delta: TextDelta = TextDelta::from_ed_delta(ed_delta, "foo");
+        let delta = TextDelta::from_ed_delta(ed_delta, "foo");
         assert_eq!(delta, delete(0, 1));
     }
 
     #[test]
     fn conversion_editor_to_text_delta_replacement() {
         let ed_delta = ed_delta_single((0, 5), (1, 0), "\nhello\n");
-        let delta: TextDelta = TextDelta::from_ed_delta(ed_delta, "hello\n");
+        let delta = TextDelta::from_ed_delta(ed_delta, "hello\n");
         let mut expected_delta = TextDelta::default();
         expected_delta.retain(5);
         expected_delta.insert("\nhello\n");
@@ -530,13 +530,13 @@ mod tests {
     #[test]
     fn conversion_editor_to_text_delta_full_line_deletion() {
         let ed_delta = ed_delta_single((0, 0), (1, 0), "");
-        let delta: TextDelta = TextDelta::from_ed_delta(ed_delta, "a");
+        let delta = TextDelta::from_ed_delta(ed_delta, "a");
         let mut expected_delta = TextDelta::default();
         expected_delta.delete(1);
         assert_eq!(expected_delta, delta);
 
         let ed_delta = ed_delta_single((0, 0), (1, 0), "");
-        let delta: TextDelta = TextDelta::from_ed_delta(ed_delta, "a\n");
+        let delta = TextDelta::from_ed_delta(ed_delta, "a\n");
         let mut expected_delta = TextDelta::default();
         expected_delta.delete(2);
         assert_eq!(expected_delta, delta);
@@ -545,7 +545,7 @@ mod tests {
     #[test]
     fn conversion_editor_to_text_delta_multiline_replacement() {
         let ed_delta = ed_delta_single((1, 0), (2, 0), "xzwei\nx");
-        let delta: TextDelta = TextDelta::from_ed_delta(ed_delta, "xeins\nzwei\ndrei\n");
+        let delta = TextDelta::from_ed_delta(ed_delta, "xeins\nzwei\ndrei\n");
         let mut expected_delta = TextDelta::default();
         expected_delta.retain(6);
         expected_delta.insert("xzwei\nx");
@@ -597,7 +597,7 @@ mod tests {
             replace_ed((0, 1), (0, 1), "long"),
             replace_ed((0, 2), (0, 2), "short"),
         ]);
-        let delta: TextDelta = TextDelta::from_ed_delta(ed_delta, "oneliner");
+        let delta = TextDelta::from_ed_delta(ed_delta, "oneliner");
         let mut expected = TextDelta::default();
         expected.retain(1);
         expected.insert("l");

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -3,6 +3,7 @@ use automerge::{Patch, PatchAction};
 use operational_transform::{Operation as OTOperation, OperationSeq};
 use ropey::Rope;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct TextDelta(pub Vec<TextOp>);
@@ -81,6 +82,23 @@ impl FileTextDelta {
     #[must_use]
     pub fn new(file_path: String, delta: TextDelta) -> Self {
         Self { file_path, delta }
+    }
+
+    pub fn from_crdt_patches(patches: Vec<Patch>) -> Vec<Self> {
+        let mut file_deltas: Vec<Self> = vec![];
+
+        for patch in patches {
+            match patch.try_into() {
+                Ok(result) => {
+                    file_deltas.push(result);
+                }
+                Err(e) => {
+                    warn!("Failed to convert patch to delta: {:#?}", e);
+                }
+            }
+        }
+
+        file_deltas
     }
 }
 

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -102,6 +102,8 @@ impl FileTextDelta {
     }
 }
 
+type DocumentUri = String;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "method", content = "params", rename_all = "camelCase")]
 pub enum EditorProtocolMessage {
@@ -141,8 +143,6 @@ impl EditorProtocolMessage {
         Ok(message)
     }
 }
-
-type DocumentUri = String;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EditorTextOp {

--- a/vim-plugin/lua/changetracker.lua
+++ b/vim-plugin/lua/changetracker.lua
@@ -4,10 +4,6 @@ local debug = require("logging").debug
 
 local M = {}
 
--- Used to remember the previous content of the buffer, so that we can
--- calculate the difference between the previous and the current content.
-local prev_lines
-
 -- Used to note that changes to the buffer should be ignored, and not be sent out as deltas.
 local ignore_edits = false
 
@@ -15,7 +11,9 @@ local ignore_edits = false
 --
 -- The delta can be expected to be in the format as specified in the daemon-editor protocol.
 function M.trackChanges(buffer, callback)
-    prev_lines = vim.api.nvim_buf_get_lines(buffer, 0, -1, true)
+    -- Used to remember the previous content of the buffer, so that we can
+    -- calculate the difference between the previous and the current content.
+    local prev_lines = vim.api.nvim_buf_get_lines(buffer, 0, -1, true)
 
     vim.api.nvim_buf_attach(buffer, false, {
         on_lines = function(

--- a/vim-plugin/lua/changetracker.lua
+++ b/vim-plugin/lua/changetracker.lua
@@ -43,6 +43,7 @@ function M.trackChanges(buffer, callback)
             debug({ diff = diff })
 
             -- TODO: Simplify the solution?
+            -- For example, pull tests into good variable names like "ends_with_newline".
             -- TODO: Update the following comment to describe the problem and the solution more clearly.
 
             -- Sometimes, Vim deletes full lines by deleting the last line, plus an imaginary newline at the end. For example, to delete the second line, Vim would delete from (line: 1, column: 0) to (line: 2, column 0).
@@ -56,7 +57,7 @@ function M.trackChanges(buffer, callback)
                     -- Instead, we just shorten the range by one character.
                     diff.range["end"].line = diff.range["end"].line - 1
                     diff.range["end"].character = vim.fn.strchars(prev_lines[#prev_lines])
-                    if string.sub(diff.text, vim.fn.strchars(diff.text)) == "\n" then
+                    if string.sub(diff.text, -1) == "\n" then
                         -- The replacement ends with a newline.
                         -- Drop it, because we shortened the range not to include the newline.
                         diff.text = string.sub(diff.text, 1, -2)
@@ -70,15 +71,14 @@ function M.trackChanges(buffer, callback)
                             -- Modify edit, s.t. not the last \n, but the one before is replaced.
                             diff.range["start"].line = diff.range["start"].line - 1
                             diff.range["end"].line = diff.range["end"].line - 1
-                            diff.range["start"].character =
-                                vim.fn.strchars(prev_lines[diff.range["start"].line + 1], false)
-                            diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1], false)
-                        elseif string.sub(diff.text, vim.fn.strchars(diff.text)) == "\n" then
+                            diff.range["start"].character = vim.fn.strchars(prev_lines[diff.range["start"].line + 1])
+                            diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1])
+                        elseif string.sub(diff.text, -1) == "\n" then
                             -- The replacement ends with a newline.
                             -- Drop it, and shorten the range by one character.
                             diff.text = string.sub(diff.text, 1, -2)
                             diff.range["end"].line = diff.range["end"].line - 1
-                            diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1], false)
+                            diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1])
                         else
                             vim.fn.echoerr(
                                 "We don't know how to handle this case for a deletion after the last visible line. Please file a bug."

--- a/vim-plugin/lua/utils.lua
+++ b/vim-plugin/lua/utils.lua
@@ -1,10 +1,5 @@
 local M = {}
 
-function M.appendNewline()
-    print("Appending newline...")
-    vim.cmd("normal! Go")
-end
-
 -- The following functions are taken from the Neovim source code:
 -- https://github.com/neovim/neovim/blob/master/runtime/lua/vim/lsp/util.lua
 
@@ -94,7 +89,6 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
     end
 
     -- Apply text edits.
-    --local has_eol_text_edit = false
     local disable_eol = false
     for _, text_edit in ipairs(text_edits) do
         -- Normalize line ending
@@ -121,7 +115,6 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
             if max <= e.end_row then
                 e.end_row = max - 1
                 e.end_col = last_line_len
-                --has_eol_text_edit = true
                 disable_eol = true
                 -- "a" + 'eol' + replace((0,1), (1,0), "") => "a" + 'noeol'
                 -- "a" + 'eol' + replace((0,1), (1,0), "\n\n") => "a\n\n" + 'noeol' (I guess?)
@@ -166,12 +159,6 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
     if disable_eol then
         vim.bo.eol = false
     end
-    --local fix_eol = has_eol_text_edit
-    --fix_eol = fix_eol and (vim.bo[bufnr].eol or (vim.bo[bufnr].fixeol and not vim.bo[bufnr].binary))
-    --fix_eol = fix_eol and get_line(bufnr, max - 1) == ""
-    --if fix_eol then
-    --    vim.api.nvim_buf_set_lines(bufnr, -2, -1, false, {})
-    --end
 end
 
 return M

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -27,7 +27,7 @@ local function processOperationForEditor(method, parameters)
 
             files[filepath].daemonRevision = files[filepath].daemonRevision + 1
         else
-            -- Operation is not up-to-date to our content, skip it!
+            -- Operation is not up-to-date to our content, ignore it!
             -- The daemon will send a transformed one later.
         end
     else
@@ -124,6 +124,10 @@ function EthersyncOpenBuffer()
 end
 
 function EthersyncCloseBuffer()
+    if vim.fn.isdirectory(vim.fn.expand("<afile>:p:h") .. "/.ethersync") ~= 1 then
+        return
+    end
+
     local closedFile = vim.fn.expand("<afile>:p")
     local filepath = vim.uri_to_fname("file://" .. closedFile)
 

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -63,7 +63,6 @@ local function connect()
             end)
 
             print("Ethersync client connection exited: ", vim.inspect({ ... }))
-            vim.defer_fn(connect, 1000)
         end,
     }
 
@@ -77,11 +76,7 @@ local function connect()
         client = vim.lsp.rpc.start(cmd, dispatchers)
     end
 
-    if client then
-        print("Connected to Ethersync daemon!")
-    else
-        vim.defer_fn(connect, 1000)
-    end
+    print("Connected to Ethersync daemon!")
 end
 
 -- Forward buffer edits to daemon as well as subscribe to daemon events ("open").


### PR DESCRIPTION
This PR introduces the first iteration of a multi-file feature. We're assuming that files are "static" (i.e. won't be renamed, added or removed after starting Ethersync) for simplicity.