### PR TITLE
Basic Cursor Awareness in Vim synchronized through automerge

### DIFF
--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -245,7 +245,7 @@ impl MockSocket {
 pub mod tests {
     use super::*;
     use crate::types::{
-        factories::*, EditorProtocolMessage, EditorTextDelta, EditorTextOp,
+        factories::*, EditorProtocolMessageFromEditor, EditorTextDelta, EditorTextOp,
         RevisionedEditorTextDelta,
     };
     use pretty_assertions::assert_eq;
@@ -304,7 +304,7 @@ pub mod tests {
                     revision: 0,
                     delta: EditorTextDelta(vec![op.clone()]),
                 };
-                let editor_message = EditorProtocolMessage::Edit {
+                let editor_message = EditorProtocolMessageFromEditor::Edit {
                     uri: format!("file://{}", file_path.display()),
                     delta: rev_editor_delta,
                 };
@@ -380,9 +380,9 @@ pub mod tests {
                 // expected ones.
                 for expected_replacement in expected_replacements {
                     let msg = socket.recv().await;
-                    let message: EditorProtocolMessage = serde_json::from_str(&msg.to_string())
+                    let message: EditorProtocolMessageFromEditor = serde_json::from_str(&msg.to_string())
                         .expect("Could not parse EditorProtocolMessage");
-                    if let EditorProtocolMessage::Edit{ delta, ..} = message {
+                    if let EditorProtocolMessageFromEditor::Edit{ delta, ..} = message {
                         let operations = delta.delta.0;
                         assert_eq!(vec![expected_replacement], operations, "Different replacements when applying input '{}' to content '{:?}'", input, initial_content);
                     } else {

--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -245,8 +245,8 @@ impl MockSocket {
 pub mod tests {
     use super::*;
     use crate::types::{
-        factories::*, EditorProtocolMessageFromEditor, EditorTextDelta, EditorTextOp,
-        RevisionedEditorTextDelta,
+        factories::*, EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor,
+        EditorTextDelta, EditorTextOp, RevisionedEditorTextDelta,
     };
     use pretty_assertions::assert_eq;
     use serial_test::serial;
@@ -304,7 +304,7 @@ pub mod tests {
                     revision: 0,
                     delta: EditorTextDelta(vec![op.clone()]),
                 };
-                let editor_message = EditorProtocolMessageFromEditor::Edit {
+                let editor_message = EditorProtocolMessageToEditor::Edit {
                     uri: format!("file://{}", file_path.display()),
                     delta: rev_editor_delta,
                 };

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -293,6 +293,7 @@ impl DocumentActor {
                         PatchEffect::CursorChange(cursor_state) => {
                             cursor_states.push(cursor_state);
                         }
+                        PatchEffect::NoEffect => {}
                     }
                 }
 

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -39,6 +39,7 @@ pub enum DocMessage {
         response_tx: oneshot::Sender<(SyncState, Option<AutomergeSyncMessage>)>,
     },
     NewEditorConnection(EditorHandle),
+    CloseEditorConnection,
 }
 
 impl fmt::Debug for DocMessage {
@@ -50,6 +51,7 @@ impl fmt::Debug for DocMessage {
             DocMessage::ReceiveSyncMessage { .. } => "<automerge internal sync rcv>",
             DocMessage::GenerateSyncMessage { .. } => "<automerge internal sync gen>",
             DocMessage::NewEditorConnection(_) => "editor connected",
+            DocMessage::CloseEditorConnection => "editor disconnected",
         };
         write!(f, "{repr}")
     }
@@ -315,6 +317,9 @@ impl DocumentActor {
                 // TODO: if we use more than one ID, we should now easily have multiple editors.
                 // Modulo managing the OT server for each of them per file...
                 self.editor_clients.insert(EditorId(0), editor_handle);
+            }
+            DocMessage::CloseEditorConnection => {
+                self.editor_clients.remove(&EditorId(0));
             }
         }
     }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -310,9 +310,11 @@ impl DocumentActor {
                 response_tx,
             } => {
                 let message = self.crdt_doc.generate_sync_message(&mut peer_state);
-                response_tx.send((peer_state, message)).expect(
-                    "Failed to send peer state and sync message in response to GenerateSyncMessage",
-                );
+                let val = response_tx.send((peer_state, message));
+
+                if let Err(val) = val {
+                    warn!("Failed to send peer state and sync message in response to GenerateSyncMessage: {val:?}");
+                }
             }
             DocMessage::NewEditorConnection(editor_handle) => {
                 // TODO: if we use more than one ID, we should now easily have multiple editors.

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -92,6 +92,9 @@ impl SocketReadActor {
             }
         }
         self.shutdown_token.cancel();
+        self.document_handle
+            .send_message(DocMessage::CloseEditorConnection)
+            .await;
         info!("Client disconnected");
     }
 }

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -8,10 +8,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace};
 
 use crate::daemon::{DocMessage, DocumentActorHandle};
-use crate::types::EditorProtocolMessage;
+use crate::types::{EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor};
 
-pub type EditorMessageSender = mpsc::Sender<EditorProtocolMessage>;
-pub type EditorMessageReceiver = mpsc::Receiver<EditorProtocolMessage>;
+pub type EditorMessageSender = mpsc::Sender<EditorProtocolMessageToEditor>;
+pub type EditorMessageReceiver = mpsc::Receiver<EditorProtocolMessageToEditor>;
 
 pub async fn spawn_editor_connection(stream: UnixStream, document_handle: DocumentActorHandle) {
     let editor_handle = EditorHandle::new(stream, document_handle.clone());
@@ -27,7 +27,8 @@ pub struct EditorHandle {
 impl EditorHandle {
     pub fn new(stream: UnixStream, document_handle: DocumentActorHandle) -> Self {
         // The document task will send messages intended for the socket connection on this channel.
-        let (socket_message_tx, socket_message_rx) = mpsc::channel::<EditorProtocolMessage>(1);
+        let (socket_message_tx, socket_message_rx) =
+            mpsc::channel::<EditorProtocolMessageToEditor>(1);
         let (stream_read, stream_write) = tokio::io::split(stream);
         let shutdown_token = CancellationToken::new();
 
@@ -41,7 +42,7 @@ impl EditorHandle {
         }
     }
 
-    pub async fn send(&self, message: EditorProtocolMessage) {
+    pub async fn send(&self, message: EditorProtocolMessageToEditor) {
         self.editor_message_tx
             .send(message)
             .await
@@ -76,7 +77,7 @@ impl SocketReadActor {
             match lines.next_line().await {
                 Ok(Some(line)) => {
                     trace!("Got a line from the client: {:#?}", line);
-                    let jsonrpc = EditorProtocolMessage::from_jsonrpc(&line)
+                    let jsonrpc = EditorProtocolMessageFromEditor::from_jsonrpc(&line)
                         .expect("Failed to parse JSON-RPC message");
                     self.document_handle
                         .send_message(DocMessage::FromEditor(jsonrpc))
@@ -114,7 +115,7 @@ impl SocketWriteActor {
         }
     }
 
-    async fn write_to_socket(&mut self, message: EditorProtocolMessage) {
+    async fn write_to_socket(&mut self, message: EditorProtocolMessageToEditor) {
         let payload = message
             .to_jsonrpc()
             .expect("Failed to serialize JSON-RPC message");

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -3,7 +3,6 @@ use automerge::{Patch, PatchAction};
 use operational_transform::{Operation as OTOperation, OperationSeq};
 use ropey::Rope;
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct TextDelta(pub Vec<TextOp>);
@@ -111,7 +110,7 @@ impl PatchEffect {
                     file_deltas.push(result);
                 }
                 Err(e) => {
-                    warn!("Failed to convert patch to delta: {:#?}", e);
+                    panic!("Failed to convert patch to delta: {:#?}", e);
                 }
             }
         }

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -87,17 +87,12 @@ impl FileTextDelta {
 
 type DocumentUri = String;
 type UserId = Vec<u8>;
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct RevisionedRanges {
-    revision: usize,
-    ranges: Vec<Range>,
-}
 
 #[derive(Serialize, Deserialize)]
 pub struct CursorState {
     pub userid: UserId,
     pub file_path: String,
-    pub ranges: RevisionedRanges,
+    pub ranges: Vec<Range>,
 }
 
 pub enum PatchEffect {
@@ -139,7 +134,7 @@ pub enum EditorProtocolMessageFromEditor {
     },
     Cursor {
         uri: DocumentUri,
-        ranges: RevisionedRanges,
+        ranges: Vec<Range>,
     },
 }
 
@@ -160,7 +155,7 @@ pub enum EditorProtocolMessageToEditor {
     Cursor {
         userid: UserId,
         uri: DocumentUri,
-        ranges: RevisionedRanges,
+        ranges: Vec<Range>,
     },
 }
 

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -86,7 +86,7 @@ impl FileTextDelta {
 }
 
 type DocumentUri = String;
-type UserId = Vec<u8>;
+type UserId = String;
 
 #[derive(Serialize, Deserialize)]
 pub struct CursorState {

--- a/vim-plugin/lua/cursor.lua
+++ b/vim-plugin/lua/cursor.lua
@@ -14,6 +14,10 @@ function M.setCursor(bufnr, user_id, ranges)
     end
     user_cursors[user_id] = {}
 
+    if not vim.api.nvim_buf_is_loaded(bufnr) then
+        return
+    end
+
     for _, range in ipairs(ranges) do
         -- Convert from LSP style ranges to Neovim style ranges.
         local e = {

--- a/vim-plugin/lua/cursor.lua
+++ b/vim-plugin/lua/cursor.lua
@@ -6,13 +6,12 @@ local cursor_namespace = vim.api.nvim_create_namespace("Ethersync")
 function M.setCursor(bufnr, user_id, ranges)
     local offset_encoding = "utf-32"
 
-    if user_cursors[user_id] == nil then
-        user_cursors[user_id] = {}
+    if user_cursors[user_id] ~= nil then
+        for _, cursor_id in ipairs(user_cursors[user_id]) do
+            vim.api.nvim_buf_del_extmark(bufnr, cursor_namespace, cursor_id)
+        end
     end
-
-    for _, cursor_id in ipairs(user_cursors[user_id]) do
-        vim.api.nvim_buf_del_extmark(bufnr, cursor_namespace, cursor_id)
-    end
+    user_cursors[user_id] = {}
 
     for _, range in ipairs(ranges) do
         -- Convert from LSP style ranges to Neovim style ranges.
@@ -23,20 +22,25 @@ function M.setCursor(bufnr, user_id, ranges)
             end_col = vim.lsp.util._get_line_byte_from_position(bufnr, range["end"], offset_encoding),
         }
 
+        -- TODO: Implement those two things?
         -- if head == anchor then
         --     anchor = head + 1
         -- end
-
         -- if head > anchor then
         --     head, anchor = anchor, head
         -- end
 
+        -- TODO:
         -- -- If the cursor is at the end of the buffer, don't show it.
         -- -- This is because otherwise, the calculation that follows (to find the location for head+1) would fail.
         -- -- TODO: Find a way to display the cursor nevertheless.
         -- if head == utils.contentOfCurrentBuffer() then
         --     return
         -- end
+
+        -- TODO:
+        -- How can we display something at the end of lines?
+        -- Virtual text, like the Copilot plugin?
 
         local cursor_id = vim.api.nvim_buf_set_extmark(bufnr, cursor_namespace, e.start_row, e.start_col, {
             hl_mode = "combine",

--- a/vim-plugin/lua/cursor.lua
+++ b/vim-plugin/lua/cursor.lua
@@ -7,8 +7,10 @@ function M.setCursor(bufnr, user_id, ranges)
     local offset_encoding = "utf-32"
 
     if user_cursors[user_id] ~= nil then
-        for _, cursor_id in ipairs(user_cursors[user_id]) do
-            vim.api.nvim_buf_del_extmark(bufnr, cursor_namespace, cursor_id)
+        for _, cursor_buffer_tuple in ipairs(user_cursors[user_id]) do
+            local old_cursor_id = cursor_buffer_tuple.cursor_id
+            local old_bufnr = cursor_buffer_tuple.bufnr
+            vim.api.nvim_buf_del_extmark(old_bufnr, cursor_namespace, old_cursor_id)
         end
     end
     user_cursors[user_id] = {}
@@ -48,7 +50,7 @@ function M.setCursor(bufnr, user_id, ranges)
             end_col = e.end_col,
             end_row = e.end_row,
         })
-        table.insert(user_cursors[user_id], cursor_id)
+        table.insert(user_cursors[user_id], { cursor_id = cursor_id, bufnr = bufnr })
     end
 end
 

--- a/vim-plugin/lua/cursor.lua
+++ b/vim-plugin/lua/cursor.lua
@@ -1,0 +1,51 @@
+local M = {}
+local user_cursors = {}
+local cursor_namespace = vim.api.nvim_create_namespace("Ethersync")
+
+-- A new set of ranges means, we delete all existing ones for that user.
+function M.setCursor(bufnr, user_id, ranges)
+    local offset_encoding = "utf-32"
+
+    if user_cursors[user_id] == nil then
+        user_cursors[user_id] = {}
+    end
+
+    for _, cursor_id in ipairs(user_cursors[user_id]) do
+        vim.api.nvim_buf_del_extmark(bufnr, cursor_namespace, cursor_id)
+    end
+
+    for _, range in ipairs(ranges) do
+        -- Convert from LSP style ranges to Neovim style ranges.
+        local e = {
+            start_row = range.start.line,
+            start_col = vim.lsp.util._get_line_byte_from_position(bufnr, range.start, offset_encoding),
+            end_row = range["end"].line,
+            end_col = vim.lsp.util._get_line_byte_from_position(bufnr, range["end"], offset_encoding),
+        }
+
+        -- if head == anchor then
+        --     anchor = head + 1
+        -- end
+
+        -- if head > anchor then
+        --     head, anchor = anchor, head
+        -- end
+
+        -- -- If the cursor is at the end of the buffer, don't show it.
+        -- -- This is because otherwise, the calculation that follows (to find the location for head+1) would fail.
+        -- -- TODO: Find a way to display the cursor nevertheless.
+        -- if head == utils.contentOfCurrentBuffer() then
+        --     return
+        -- end
+
+        local cursor_id = vim.api.nvim_buf_set_extmark(bufnr, cursor_namespace, e.start_row, e.start_col, {
+            hl_mode = "combine",
+            hl_group = "TermCursor",
+            end_col = e.end_col,
+            end_row = e.end_row,
+        })
+        table.insert(user_cursors[user_id], cursor_id)
+    end
+end
+
+return M

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -35,7 +35,6 @@ local function processOperationForEditor(method, parameters)
         end
     elseif method == "cursor" then
         uri = parameters.uri
-        print("Got URI " .. uri)
         filepath = vim.uri_to_fname(uri)
         local ranges = parameters.ranges
         local userid = parameters.userid

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -37,24 +37,24 @@ local function processOperationForEditor(method, parameters)
         uri = parameters.uri
         print("Got URI " .. uri)
         filepath = vim.uri_to_fname(uri)
-        local ranges = parameters.ranges.ranges
+        local ranges = parameters.ranges
         local userid = parameters.userid
-        theEditorRevision = parameters.ranges.revision
-        if theEditorRevision == files[filepath].editorRevision then
-            -- Find correct buffer to apply edits to.
-            local bufnr = vim.uri_to_bufnr(uri)
-            local ranges_se = {}
-            for _, range in ipairs(ranges) do
-                table.insert(ranges_se, {
-                    start = range.anchor,
-                    ["end"] = range.head,
-                })
-            end
-            cursor.setCursor(bufnr, userid, ranges_se)
-        else
-            -- Operation is not up-to-date to our content, ignore it!
-            -- The daemon will send a transformed one later.
+        --theEditorRevision = parameters.ranges.revision
+        --if theEditorRevision == files[filepath].editorRevision then
+        -- Find correct buffer to apply edits to.
+        local bufnr = vim.uri_to_bufnr(uri)
+        local ranges_se = {}
+        for _, range in ipairs(ranges) do
+            table.insert(ranges_se, {
+                start = range.anchor,
+                ["end"] = range.head,
+            })
         end
+        cursor.setCursor(bufnr, userid, ranges_se)
+        --else
+        --    -- Operation is not up-to-date to our content, ignore it!
+        --    -- The daemon will send a transformed one later.
+        --end
     else
         print("Unknown method: " .. method)
     end

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -149,6 +149,10 @@ function EthersyncOpenBuffer()
 
         sendNotification("edit", params)
     end)
+    cursor.trackCursor(0, function(ranges)
+        local params = { uri = uri, ranges = ranges }
+        sendNotification("cursor", params)
+    end)
 end
 
 function EthersyncCloseBuffer()

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -17,6 +17,7 @@ local function processOperationForEditor(method, parameters)
     local uri, filepath, theEditorRevision
     if method == "edit" then
         uri = parameters.uri
+        -- TODO: Determine the proper filepath (relative to project dir).
         filepath = vim.uri_to_fname(uri)
         local delta = parameters.delta.delta
         theEditorRevision = parameters.delta.revision


### PR DESCRIPTION
This PR adds a first iteration on cursor awareness. The decision on how to approach it can be found in ADR-07 (#23). This feature currently shows the cursor when it's there, but doesn't properly hide it again if a peer disconnects.