### PR TITLE
Using another set nix github actions with the idea to speed up CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,8 +23,10 @@ jobs:
       run:
         working-directory: ./daemon
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Install Nix
-          uses: cachix/install-nix-action@v17
+          uses: DeterminateSystems/nix-installer-action@main
+        - name: Install Magic Nix Cache
+          uses: DeterminateSystems/magic-nix-cache-action@main
         - name: Run fuzzer
           run: nix develop --command cargo run --bin=fuzzer

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
-        uses: cachix/install-nix-action@v17
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Install Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix develop --command cargo build --verbose
       - name: Run unit tests
         run: nix develop --command cargo test --verbose -- --include-ignored

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -9,6 +9,7 @@ use tracing::{error, info};
 mod jsonrpc_forwarder;
 
 const DEFAULT_SOCKET_PATH: &str = "/tmp/ethersync";
+const DEFAULT_PORT: &str = "4242";
 const ETHERSYNC_CONFIG_DIR: &str = ".ethersync";
 
 #[derive(Parser)]
@@ -31,9 +32,9 @@ enum Commands {
     Daemon {
         // TODO: Move the default port definition to a constant.
         /// Port to listen on as a hosting peer.
-        #[arg(short, long, default_value = "4242")]
+        #[arg(short, long, default_value = DEFAULT_PORT)]
         port: Option<u16>,
-        /// The directory to sync.
+        /// The directory to sync. Defaults to current directory.
         directory: Option<PathBuf>,
         /// IP + port of a peer to connect to. Example: 192.168.1.42:1234
         #[arg(long)]


### PR DESCRIPTION
This PR is probably suffering a bit from premature optimization. And also, I don't really know what I'm doing.

Basically I have switched from https://github.com/cachix/install-nix-action to https://github.com/DeterminateSystems/nix-installer-action + https://github.com/DeterminateSystems/magic-nix-cache-action.
The effect is that the two Action "Rust Daemon" and "Integration Test" are running a bit faster. Not the [promised](https://github.com/DeterminateSystems/magic-nix-cache-action) 30%+, but something like 20%? And it has magic in it's name! 🧙🏼 

Unscientific [science](https://xkcd.com/882/):

| Action           | Before this PR | In this PR | Relative decrease |
|------------------|----------------|------------|-------------------|
| [Rust Daemon](https://github.com/ethersync/ethersync/actions/workflows/rust.yml)      | 440s           | 338s       | 23%               |
| [Integration Test](https://github.com/ethersync/ethersync/actions/workflows/integration.yml) | 480s           | 387s       | 19%               |

But I don't know when caching happens and to what extent and this is not a long term study but I picked numbers that I liked and found somewhat representative from the action runs. Still, it might not hurt (besides having the dependency on the determinate systems cache? It seems to be [throttled / timing out](https://github.com/ethersync/ethersync/actions/runs/9884061546/job/27299829941?pr=50#step:5:379) at times and then I guess we're on our own again.)

btw, minor code and dependency changes. We can keep them or take them out... I used these changes to trigger the Actions.