### PR TITLE
editor jsonrpc requests

### DIFF
--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -245,8 +245,8 @@ impl MockSocket {
 pub mod tests {
     use super::*;
     use crate::types::{
-        factories::*, EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor,
-        EditorProtocolRequestFromEditor, EditorTextDelta, EditorTextOp, RevisionedEditorTextDelta,
+        factories::*, EditorProtocolMessageToEditor, EditorProtocolRequestFromEditor,
+        EditorTextDelta, EditorTextOp, JSONRPCFromEditor, RevisionedEditorTextDelta,
     };
     use pretty_assertions::assert_eq;
     use serial_test::serial;
@@ -380,9 +380,9 @@ pub mod tests {
                 // expected ones.
                 while !expected_replacements.is_empty() {
                     let msg = socket.recv().await;
-                    let message: EditorProtocolMessageFromEditor = serde_json::from_str(&msg.to_string())
+                    let message: JSONRPCFromEditor = serde_json::from_str(&msg.to_string())
                         .expect("Could not parse EditorProtocolMessage");
-                    let EditorProtocolMessageFromEditor::Request{
+                    let JSONRPCFromEditor::Request{
                         payload: EditorProtocolRequestFromEditor::Edit{ delta, ..},
                         ..
                     } = message else {continue;};

--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -382,12 +382,13 @@ pub mod tests {
                     let msg = socket.recv().await;
                     let message: EditorProtocolMessageFromEditor = serde_json::from_str(&msg.to_string())
                         .expect("Could not parse EditorProtocolMessage");
-                    if let EditorProtocolMessageFromEditor::Request{payload, ..} = message {
-                        if let EditorProtocolRequestFromEditor::Edit{ delta, ..} = payload {
-                        let expected_replacement = expected_replacements.remove(0);
-                        let operations = delta.delta.0;
-                        assert_eq!(vec![expected_replacement], operations, "Different replacements when applying input '{}' to content '{:?}'", input, initial_content);
-                    }}
+                    let EditorProtocolMessageFromEditor::Request{
+                        payload: EditorProtocolRequestFromEditor::Edit{ delta, ..},
+                        ..
+                    } = message else {continue;};
+                    let expected_replacement = expected_replacements.remove(0);
+                    let operations = delta.delta.0;
+                    assert_eq!(vec![expected_replacement], operations, "Different replacements when applying input '{}' to content '{:?}'", input, initial_content);
                 }
             })
             .await

--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -246,7 +246,7 @@ pub mod tests {
     use super::*;
     use crate::types::{
         factories::*, EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor,
-        EditorTextDelta, EditorTextOp, RevisionedEditorTextDelta,
+        EditorProtocolRequestFromEditor, EditorTextDelta, EditorTextOp, RevisionedEditorTextDelta,
     };
     use pretty_assertions::assert_eq;
     use serial_test::serial;
@@ -382,11 +382,12 @@ pub mod tests {
                     let msg = socket.recv().await;
                     let message: EditorProtocolMessageFromEditor = serde_json::from_str(&msg.to_string())
                         .expect("Could not parse EditorProtocolMessage");
-                    if let EditorProtocolMessageFromEditor::Edit{ delta, ..} = message {
+                    if let EditorProtocolMessageFromEditor::Request{payload, ..} = message {
+                        if let EditorProtocolRequestFromEditor::Edit{ delta, ..} = payload {
                         let expected_replacement = expected_replacements.remove(0);
                         let operations = delta.delta.0;
                         assert_eq!(vec![expected_replacement], operations, "Different replacements when applying input '{}' to content '{:?}'", input, initial_content);
-                    }
+                    }}
                 }
             })
             .await

--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -245,7 +245,7 @@ impl MockSocket {
 pub mod tests {
     use super::*;
     use crate::types::{
-        factories::*, EditorProtocolMessageToEditor, EditorProtocolRequestFromEditor,
+        factories::*, EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor,
         EditorTextDelta, EditorTextOp, JSONRPCFromEditor, RevisionedEditorTextDelta,
     };
     use pretty_assertions::assert_eq;
@@ -383,7 +383,7 @@ pub mod tests {
                     let message: JSONRPCFromEditor = serde_json::from_str(&msg.to_string())
                         .expect("Could not parse EditorProtocolMessage");
                     let JSONRPCFromEditor::Request{
-                        payload: EditorProtocolRequestFromEditor::Edit{ delta, ..},
+                        payload: EditorProtocolMessageFromEditor::Edit{ delta, ..},
                         ..
                     } = message else {continue;};
                     let expected_replacement = expected_replacements.remove(0);

--- a/daemon/src/actors.rs
+++ b/daemon/src/actors.rs
@@ -246,7 +246,8 @@ pub mod tests {
     use super::*;
     use crate::types::{
         factories::*, EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor,
-        EditorTextDelta, EditorTextOp, JSONRPCFromEditor, RevisionedEditorTextDelta,
+        EditorProtocolObject, EditorTextDelta, EditorTextOp, JSONRPCFromEditor,
+        RevisionedEditorTextDelta,
     };
     use pretty_assertions::assert_eq;
     use serial_test::serial;
@@ -308,8 +309,7 @@ pub mod tests {
                     uri: format!("file://{}", file_path.display()),
                     delta: rev_editor_delta,
                 };
-                let payload = editor_message
-                    .to_jsonrpc()
+                let payload = EditorProtocolObject::Request(editor_message).to_jsonrpc()
                     .expect("Could not serialize EditorTextDelta");
                 socket.send(&format!("{payload}\n")).await;
             }

--- a/daemon/src/connect.rs
+++ b/daemon/src/connect.rs
@@ -67,10 +67,11 @@ async fn accept_editor_loop(
 
     loop {
         let (stream, _addr) = listener.accept().await?;
-        info!("Editor connection established");
 
-        // TODO: we need to get rid of this await to accept multiple editors.
-        spawn_editor_connection(stream, document_handle.clone()).await;
+        let id = document_handle.next_editor_id();
+        info!("Editor connection established (#{})", id.0);
+
+        spawn_editor_connection(stream, document_handle.clone(), id).await;
     }
 }
 

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -57,17 +57,17 @@ pub enum DocMessage {
 impl fmt::Debug for DocMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let repr = match self {
-            DocMessage::GetContent { .. } => "get content",
+            DocMessage::GetContent { .. } => "get content".to_string(),
             DocMessage::FromEditor(EditorId(i), _) => {
-                &format!("open/close/edit/... message from editor #{i}")
+                format!("open/close/edit/... message from editor #{i}")
             }
-            DocMessage::RemoveFile { .. } => "delete file",
-            DocMessage::Persist => "persist",
-            DocMessage::RandomEdit => "random edit",
-            DocMessage::ReceiveSyncMessage { .. } => "<automerge internal sync rcv>",
-            DocMessage::GenerateSyncMessage { .. } => "<automerge internal sync gen>",
-            DocMessage::NewEditorConnection(_) => "editor connected",
-            DocMessage::CloseEditorConnection(EditorId(i)) => &format!("editor #{i} disconnected"),
+            DocMessage::RemoveFile { .. } => "delete file".to_string(),
+            DocMessage::Persist => "persist".to_string(),
+            DocMessage::RandomEdit => "random edit".to_string(),
+            DocMessage::ReceiveSyncMessage { .. } => "<automerge internal sync rcv>".to_string(),
+            DocMessage::GenerateSyncMessage { .. } => "<automerge internal sync gen>".to_string(),
+            DocMessage::NewEditorConnection(_) => "editor connected".to_string(),
+            DocMessage::CloseEditorConnection(EditorId(i)) => format!("editor #{i} disconnected"),
         };
         write!(f, "{repr}")
     }

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -157,6 +157,7 @@ impl Document {
         };
 
         debug!("Removing {file_path} from CRDT.");
+        // TODO: Also remove it from ot server, if applicable
         let file_map = self
             .top_level_map_obj("files")
             .expect("Failed to get files Map object");
@@ -196,6 +197,10 @@ impl Document {
             .top_level_map_obj("files")
             .expect("Failed to get files store from document");
         self.doc.keys(file_map).collect()
+    }
+
+    pub fn file_exists(&self, file_path: &str) -> bool {
+        self.text_obj(file_path).is_ok()
     }
 
     pub fn store_cursor_position(&mut self, userid: String, file_path: String, ranges: Vec<Range>) {

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace};
 
 use crate::daemon::{DocMessage, DocumentActorHandle};
-use crate::types::{EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor};
+use crate::types::{EditorProtocolMessageToEditor, JSONRPCFromEditor};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct EditorId(pub usize);
@@ -106,7 +106,7 @@ impl SocketReadActor {
             match lines.next_line().await {
                 Ok(Some(line)) => {
                     trace!("Got a line from the client: {:#?}", line);
-                    let jsonrpc = EditorProtocolMessageFromEditor::from_jsonrpc(&line)
+                    let jsonrpc = JSONRPCFromEditor::from_jsonrpc(&line)
                         .expect("Failed to parse JSON-RPC message");
                     self.document_handle
                         .send_message(DocMessage::FromEditor(self.editor_id, jsonrpc))

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -129,11 +129,11 @@ pub enum JSONRPCFromEditor {
     Request {
         id: usize,
         #[serde(flatten)]
-        payload: EditorProtocolRequestFromEditor,
+        payload: EditorProtocolMessageFromEditor,
     },
     Notification {
         #[serde(flatten)]
-        payload: EditorProtocolNotificationFromEditor,
+        payload: EditorProtocolMessageFromEditor,
     },
 }
 impl JSONRPCFromEditor {
@@ -146,26 +146,27 @@ impl JSONRPCFromEditor {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "method", content = "params", rename_all = "camelCase")]
-pub enum EditorProtocolRequestFromEditor {
+pub enum EditorProtocolMessageFromEditor {
     Open {
+        uri: DocumentUri,
+    },
+    Close {
         uri: DocumentUri,
     },
     Edit {
         uri: DocumentUri,
         delta: RevisionedEditorTextDelta,
     },
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "method", content = "params", rename_all = "camelCase")]
-pub enum EditorProtocolNotificationFromEditor {
-    Close {
-        uri: DocumentUri,
-    },
     Cursor {
         uri: DocumentUri,
         ranges: Vec<Range>,
     },
+}
+
+pub struct EditorProtocolMessageError {
+    pub code: i32,
+    pub message: String,
+    pub data: String,
 }
 
 #[cfg(test)]
@@ -183,7 +184,7 @@ mod test_serde {
             message.unwrap(),
             JSONRPCFromEditor::Request {
                 id: 1,
-                payload: EditorProtocolRequestFromEditor::Open {
+                payload: EditorProtocolMessageFromEditor::Open {
                     uri: "file:///tmp/file".into()
                 }
             }
@@ -235,7 +236,7 @@ pub enum EditorProtocolMessageToEditor {
     },
     RequestError {
         id: usize,
-        code: i64,
+        code: i32,
         message: String,
         // We could change this datatype, if we wanted to.
         data: String,

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -125,7 +125,7 @@ impl PatchEffect {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum EditorProtocolMessageFromEditor {
+pub enum JSONRPCFromEditor {
     Request {
         id: usize,
         #[serde(flatten)]
@@ -136,7 +136,7 @@ pub enum EditorProtocolMessageFromEditor {
         payload: EditorProtocolNotificationFromEditor,
     },
 }
-impl EditorProtocolMessageFromEditor {
+impl JSONRPCFromEditor {
     pub fn from_jsonrpc(jsonrpc: &str) -> Result<Self, anyhow::Error> {
         let error_message = format!("Failed to deserialize editor message: {jsonrpc}");
         let message = serde_json::from_str(jsonrpc).expect(&error_message);
@@ -176,12 +176,12 @@ mod test_serde {
 
     #[test]
     fn open() {
-        let message = EditorProtocolMessageFromEditor::from_jsonrpc(
+        let message = JSONRPCFromEditor::from_jsonrpc(
             r#"{"jsonrpc":"2.0","id":1,"method":"open","params":{"uri":"file:\/\/\/tmp\/file"}}"#,
         );
         assert_eq!(
             message.unwrap(),
-            EditorProtocolMessageFromEditor::Request {
+            JSONRPCFromEditor::Request {
                 id: 1,
                 payload: EditorProtocolRequestFromEditor::Open {
                     uri: "file:///tmp/file".into()

--- a/vim-plugin/lua/changetracker.lua
+++ b/vim-plugin/lua/changetracker.lua
@@ -80,13 +80,13 @@ function M.track_changes(buffer, callback)
                             diff.range["end"].line = diff.range["end"].line - 1
                             diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1])
                         else
-                            vim.fn.echoerr(
-                                "We don't know how to handle this case for a deletion after the last visible line. Please file a bug."
+                            vim.api.nvim_err_writeln(
+                                "[ethersync] We don't know how to handle this case for a deletion after the last visible line. Please file a bug."
                             )
                         end
                     else
-                        vim.fn.echoerr(
-                            "We think a delta ending inside the line after the visible ones cannot happen. Please file a bug."
+                        vim.api.nvim_err_writeln(
+                            "[ethersync] We think a delta ending inside the line after the visible ones cannot happen. Please file a bug."
                         )
                     end
                 end

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -14,12 +14,7 @@ end
 
 local function send_request(method, params)
     client.request(method, params, function(err, res)
-        print("GOT RESPO")
-        if err then
-            print("had error: " .. vim.inspect(err))
-        else
-            print("with res: " .. vim.inspect(res))
-        end
+        -- TODO: React somehow!
     end)
 end
 

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -13,8 +13,14 @@ local function send_notification(method, params)
 end
 
 local function send_request(method, params)
-    client.request(method, params, function(err, res)
-        -- TODO: React somehow!
+    client.request(method, params, function(err, _)
+        if err then
+            local error_msg = "[ethersync] Error for '" .. method .. "': " .. err.message
+            if err.data then
+                error_msg = error_msg .. " (" .. err.data .. ")"
+            end
+            vim.api.nvim_err_writeln(error_msg)
+        end
     end)
 end
 

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -12,6 +12,16 @@ local function send_notification(method, params)
     client.notify(method, params)
 end
 
+local function send_request(method, params)
+    client.request(method, params, function(err, res)
+        print("GOT RESPO")
+        if err then
+            print("had error: " .. vim.inspect(err))
+        end
+        print("with res: " .. vim.inspect(res))
+    end)
+end
+
 -- Take an operation from the daemon and apply it to the editor.
 local function process_operation_for_editor(method, parameters)
     if method == "edit" then
@@ -102,7 +112,7 @@ local function on_buffer_open()
     }
 
     local uri = "file://" .. filename
-    send_notification("open", { uri = uri })
+    send_request("open", { uri = uri })
 
     -- Vim enables eol for an empty file, but we do use this option values
     -- assuming there's a trailing newline iff eol is true.
@@ -120,7 +130,7 @@ local function on_buffer_open()
 
         local params = { uri = uri, delta = rev_delta }
 
-        send_notification("edit", params)
+        send_request("edit", params)
     end)
     cursor.track_cursor(0, function(ranges)
         local params = { uri = uri, ranges = ranges }

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -17,8 +17,9 @@ local function send_request(method, params)
         print("GOT RESPO")
         if err then
             print("had error: " .. vim.inspect(err))
+        else
+            print("with res: " .. vim.inspect(res))
         end
-        print("with res: " .. vim.inspect(res))
     end)
 end
 


### PR DESCRIPTION
In order to communicate error back to the editor, we need to implement JSON-RPC responses.
This PR brings does and uses them in a not-yet-sophisticated way in the neovim plugin: By printing it to the user.