### PR TITLE
Some lints and refactorings

### DIFF
--- a/daemon/clippy.toml
+++ b/daemon/clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/daemon/src/bin/fuzzer.rs
+++ b/daemon/src/bin/fuzzer.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 use ethersync::actors::{Actor, Neovim};
+use ethersync::connect::PeerConnectionInfo;
 use ethersync::daemon::{Daemon, TEST_FILE_PATH};
 use ethersync::logging;
 use ethersync::sandbox;
@@ -49,8 +50,7 @@ async fn main() {
 
     // Set up the actors.
     let daemon = Daemon::new(
-        Some(2424),
-        None,
+        PeerConnectionInfo::Accept(2424),
         Path::new("/tmp/ethersync"),
         dir.path(),
         true,
@@ -59,8 +59,7 @@ async fn main() {
     let nvim = Neovim::new(file).await;
 
     let peer = Daemon::new(
-        None,
-        Some("127.0.0.1:2424".to_string()),
+        PeerConnectionInfo::Connect("127.0.0.1:2424".to_string()),
         Path::new("/tmp/etherbonk"),
         dir2.path(),
         false,

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -85,7 +85,7 @@ pub struct DocumentActor {
     doc_message_rx: mpsc::Receiver<DocMessage>,
     doc_changed_ping_tx: DocChangedSender,
     editor_clients: HashMap<EditorId, EditorHandle>,
-    /// If we have an ot_server for a given file, it means that editor has ownership.
+    /// If we have an `ot_server` for a given file, it means that editor has ownership.
     ot_servers: HashMap<String, OTServer>,
     /// The Document is the main I/O managed resource of this actor.
     crdt_doc: Document,

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -337,7 +337,7 @@ impl DocumentActor {
             Ok(text) => text,
             Err(_) => {
                 // The file doesn't exist yet - create it in the Automerge document.
-                let text = "".to_string();
+                let text = String::new();
                 self.crdt_doc.initialize_text(&text, &file_path);
                 text
             }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -695,14 +695,12 @@ pub struct Daemon {
 impl Daemon {
     // Launch the daemon. Optionally, connect to given peer.
     pub fn new(
-        port: Option<u16>,
-        peer: Option<String>,
+        peer_connection_info: connect::PeerConnectionInfo,
         socket_path: &Path,
         base_dir: &Path,
         init: bool,
     ) -> Self {
-        // If the peer address is empty, we're the host.
-        let is_host = peer.is_none();
+        let is_host = peer_connection_info.is_host();
 
         let document_handle = DocumentActorHandle::new(base_dir, init, is_host);
 
@@ -731,9 +729,8 @@ impl Daemon {
         });
 
         let connection_document_handle = document_handle.clone();
-        let peer_info = connect::PeerConnectionInfo::new(port, peer);
         tokio::spawn(async move {
-            connect::make_peer_connection(peer_info, connection_document_handle).await;
+            connect::make_peer_connection(peer_connection_info, connection_document_handle).await;
         });
 
         let editor_socket_path = socket_path.to_path_buf();

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -237,7 +237,7 @@ impl DocumentActor {
                 self.editor_clients.remove(&editor_id);
 
                 let userid = self.crdt_doc.actor_id();
-                self.maybe_delete_cursor_position(userid);
+                self.maybe_delete_cursor_position(&userid);
             }
         }
     }
@@ -301,7 +301,7 @@ impl DocumentActor {
             EditorProtocolMessageFromEditor::Cursor { uri, ranges } => {
                 let file_path = self.file_path_for_uri(&uri);
                 let userid = self.crdt_doc.actor_id();
-                self.store_cursor_position(userid, file_path, ranges);
+                self.store_cursor_position(&userid, file_path, ranges);
             }
         }
         Ok(())
@@ -597,13 +597,13 @@ impl DocumentActor {
         self.maybe_write_file(file_path);
     }
 
-    fn store_cursor_position(&mut self, userid: String, file_path: String, ranges: Vec<Range>) {
+    fn store_cursor_position(&mut self, userid: &str, file_path: String, ranges: Vec<Range>) {
         self.crdt_doc
             .store_cursor_position(userid, file_path, ranges);
         let _ = self.doc_changed_ping_tx.send(());
     }
 
-    fn maybe_delete_cursor_position(&mut self, userid: String) {
+    fn maybe_delete_cursor_position(&mut self, userid: &str) {
         self.crdt_doc.maybe_delete_cursor_position(userid);
         let _ = self.doc_changed_ping_tx.send(());
     }

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -37,7 +37,7 @@ impl Document {
     }
     pub fn load(bytes: &[u8]) -> Self {
         let doc =
-            AutoCommit::load(&bytes).expect("Failed to load Automerge document from given bytes");
+            AutoCommit::load(bytes).expect("Failed to load Automerge document from given bytes");
         Self { doc }
     }
 

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -209,16 +209,16 @@ impl Document {
         self.text_obj(file_path).is_ok()
     }
 
-    pub fn store_cursor_position(&mut self, userid: String, file_path: String, ranges: Vec<Range>) {
+    pub fn store_cursor_position(&mut self, userid: &str, file_path: String, ranges: Vec<Range>) {
         let state_map = self
             .top_level_map_obj("states")
             .expect("Failed to get states Map object");
         let user_obj = self
             .doc
-            .put_object(state_map, &userid, ObjType::Text)
+            .put_object(state_map, userid, ObjType::Text)
             .expect("Failed to initialize user state Map object in Automerge document");
         let cursor_state = CursorState {
-            userid: userid.clone(),
+            userid: userid.to_owned(),
             name: env::var("USER").ok(),
             file_path,
             ranges,
@@ -230,11 +230,11 @@ impl Document {
         debug!("Stored user state for '{userid}': {data}");
     }
 
-    pub fn maybe_delete_cursor_position(&mut self, userid: String) {
+    pub fn maybe_delete_cursor_position(&mut self, userid: &str) {
         // We try to set an empty cursor position, but in case we don't have any file in the
         // project its not a big deal if it stays.
         if let Some(file_path) = self.get_valid_file_path() {
-            self.store_cursor_position(userid, file_path, vec![])
+            self.store_cursor_position(userid, file_path, vec![]);
         }
     }
 

--- a/daemon/src/jsonrpc_forwarder.rs
+++ b/daemon/src/jsonrpc_forwarder.rs
@@ -36,7 +36,7 @@ pub fn connection(socket_path: &Path) {
         data.push(byte);
 
         if reading_header {
-            if data.ends_with(&[b'\r', b'\n', b'\r', b'\n']) {
+            if data.ends_with(b"\r\n\r\n") {
                 let header_string = from_utf8(&data).expect("Failed to parse header as UTF-8");
                 content_length = 0;
                 for line in header_string.lines() {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -45,12 +45,11 @@ enum Commands {
     Client,
 }
 
-fn has_ethersync_directory(dir: PathBuf) -> bool {
-    let mut ethersync_dir = dir.clone();
-    ethersync_dir.push(ETHERSYNC_CONFIG_DIR);
+fn has_ethersync_directory(dir: &Path) -> bool {
+    let ethersync_dir = dir.join(ETHERSYNC_CONFIG_DIR);
     // Using the sandbox method here is technically unnecessary,
     // but we want to really run all path operations through the sandbox module.
-    sandbox::exists(&dir, &ethersync_dir).expect("Failed to check") && ethersync_dir.is_dir()
+    sandbox::exists(dir, &ethersync_dir).expect("Failed to check") && ethersync_dir.is_dir()
 }
 
 #[tokio::main]
@@ -78,7 +77,7 @@ async fn main() -> io::Result<()> {
                 .unwrap_or(std::env::current_dir().expect("Could not access current directory"))
                 .canonicalize()
                 .expect("Could not access given directory");
-            if !has_ethersync_directory(directory.clone()) {
+            if !has_ethersync_directory(&directory) {
                 error!(
                     "No {} found in {} (create it to Ethersync-enable the directory)",
                     ETHERSYNC_CONFIG_DIR,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use ethersync::connect::PeerConnectionInfo;
 use ethersync::{daemon::Daemon, logging, sandbox};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -87,8 +88,13 @@ async fn main() -> io::Result<()> {
                 );
                 return Ok(());
             }
+            let peer_connection_info = if let Some(peer) = peer {
+                PeerConnectionInfo::Connect(peer)
+            } else {
+                PeerConnectionInfo::Accept(port)
+            };
             info!("Starting Ethersync on {}", directory.display());
-            Daemon::new(Some(port), peer, &socket_path, &directory, init);
+            Daemon::new(peer_connection_info, &socket_path, &directory, init);
             match signal::ctrl_c().await {
                 Ok(()) => {}
                 Err(err) => {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -74,7 +74,9 @@ async fn main() -> io::Result<()> {
             init,
         } => {
             let directory = directory
-                .unwrap_or(std::env::current_dir().expect("Could not access current directory"))
+                .unwrap_or_else(|| {
+                    std::env::current_dir().expect("Could not access current directory")
+                })
                 .canonicalize()
                 .expect("Could not access given directory");
             if !has_ethersync_directory(&directory) {

--- a/daemon/src/ot.rs
+++ b/daemon/src/ot.rs
@@ -71,7 +71,7 @@ pub struct OTServer {
     editor_queue: Vec<OperationSeq>,
     current_content: String,
     /// That's the content we assume the editor has, where the operations it sends us apply.
-    /// (which is the content "in front" of the editor_queue)
+    /// (which is the content "in front" of the `editor_queue`)
     last_confirmed_editor_content: String,
 }
 


### PR DESCRIPTION
Ran a bunch of clippy lints, mainly pedantic ones and improved things I saw while looking at the code.

I tried to split them into their own commits. Feel free to cherry-pick or deny some of them. I can rebase and remove commits if wished for.

A good idea might also be to [configure lints in the `Cargo.toml`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-lints-section).