### PR TITLE
Write a file (if needed) after an editor sends "close"

### DIFF
--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -316,6 +316,10 @@ impl DocumentActor {
                     .map_err(anyhow_err_to_protocol_err)?;
                 debug!("Got a 'close' message for {file_path}");
                 self.ot_servers.remove(&file_path);
+
+                // TODO: As soon as we support multiple editor connections, only do this if no
+                // editor is connected anymore.
+                self.maybe_write_file(&file_path);
             }
             EditorProtocolMessageFromEditor::Cursor { uri, ranges } => {
                 let file_path = self


### PR DESCRIPTION
This avoids a bug where, if the user doesn't save a file, the file content and the CRDT content are inconsistent.

This fixes #65.