### PR TITLE
When receiving faulty JSON-RPC on the socket, send an error back to the caller

### DIFF
--- a/daemon/src/bin/fuzzer.rs
+++ b/daemon/src/bin/fuzzer.rs
@@ -64,6 +64,8 @@ async fn main() {
     sleep(std::time::Duration::from_millis(5000)).await;
 
     let nvim = Neovim::new(file).await;
+    // Give the editor time to process the open.
+    sleep(std::time::Duration::from_millis(5000)).await;
 
     let peer = Daemon::new(
         PeerConnectionInfo {
@@ -102,7 +104,7 @@ async fn main() {
 
     info!("Waiting for all contents to be equal");
 
-    timeout(Duration::from_secs(60), async {
+    timeout(Duration::from_secs(5 * 60), async {
         loop {
             // Get all contents.
             for (name, actor) in &mut actors {
@@ -121,7 +123,7 @@ async fn main() {
             if all_equal {
                 break;
             }
-            sleep(Duration::from_millis(100)).await;
+            sleep(Duration::from_millis(1000)).await;
         }
     })
     .await

--- a/daemon/src/bin/fuzzer.rs
+++ b/daemon/src/bin/fuzzer.rs
@@ -13,7 +13,7 @@ use tokio::time::{sleep, timeout, Duration};
 use tracing::{error, info};
 
 async fn perform_random_edits(actor: &mut (impl Actor + ?Sized)) {
-    for _ in 1..100 {
+    for _ in 1..500 {
         actor.apply_random_delta().await;
 
         let random_millis = rand::thread_rng().gen_range(0..5);

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace};
 
 use crate::daemon::{DocMessage, DocumentActorHandle};
-use crate::types::{EditorProtocolObject, JSONRPCFromEditor};
+use crate::types::EditorProtocolObject;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct EditorId(pub usize);
@@ -105,10 +105,8 @@ impl SocketReadActor {
             match lines.next_line().await {
                 Ok(Some(line)) => {
                     trace!("Got a line from the client: {:#?}", line);
-                    let jsonrpc = JSONRPCFromEditor::from_jsonrpc(&line)
-                        .expect("Failed to parse JSON-RPC message");
                     self.document_handle
-                        .send_message(DocMessage::FromEditor(self.editor_id, jsonrpc))
+                        .send_message(DocMessage::FromEditor(self.editor_id, line))
                         .await;
                 }
                 Ok(None) => {

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -139,8 +139,7 @@ pub enum JSONRPCFromEditor {
 }
 impl JSONRPCFromEditor {
     pub fn from_jsonrpc(jsonrpc: &str) -> Result<Self, anyhow::Error> {
-        let error_message = format!("Failed to deserialize editor message: {jsonrpc}");
-        let message = serde_json::from_str(jsonrpc).expect(&error_message);
+        let message = serde_json::from_str(jsonrpc)?;
         Ok(message)
     }
 }
@@ -168,7 +167,7 @@ pub enum EditorProtocolMessageFromEditor {
 pub struct EditorProtocolMessageError {
     pub code: i32,
     pub message: String,
-    pub data: String,
+    pub data: Option<String>,
 }
 
 #[cfg(test)]
@@ -209,11 +208,11 @@ mod test_serde {
     #[test]
     fn error() {
         let message = EditorProtocolObject::Response(JSONRPCResponse::RequestError {
-            id: 1,
+            id: Some(1),
             error: EditorProtocolMessageError {
                 code: -1,
                 message: "title".into(),
-                data: "content".into(),
+                data: Some("content".into()),
             },
         });
         let jsonrpc = message.to_jsonrpc();
@@ -268,7 +267,8 @@ pub enum JSONRPCResponse {
         result: String,
     },
     RequestError {
-        id: usize,
+        // id must be Null if there was an error detecting the id in the Request Object.
+        id: Option<usize>,
         error: EditorProtocolMessageError,
     },
 }


### PR DESCRIPTION
This should make it easier to develop editor plugins, when you get feedback that your message couldn't get parsed.

Partial fix for #29.