### PR TITLE
Emacs plugin

### DIFF
--- a/emacs-plugin/ethersync.el
+++ b/emacs-plugin/ethersync.el
@@ -233,6 +233,16 @@ reading and writing JSONRPC messages with basic HTTP-style enveloping headers su
     (or (ethersync--scan-for-matching-socket-path socket-location)
         (push (ethersync--create-client-process socket-location) ethersync--active-clients))))
 
+;;;###autoload
+(defun ethersync-clear-all-clients ()
+  "Iterate through every attached client and kill its process."
+  (interactive)
+  (cl-loop for client = (pop ethersync--active-clients)
+           while client
+           for sock-proc = (ethersync--client-process client)
+           for proc-buf = (process-buffer sock-proc)
+           do (kill-buffer proc-buf)))
+
 
 (provide 'ethersync)
 ;;; ethersync.el ends here

--- a/emacs-plugin/ethersync.el
+++ b/emacs-plugin/ethersync.el
@@ -209,9 +209,15 @@ connection object, called when the process dies.")
          (client (make-instance
                   'ethersync-client
                   :name ethersync--connection-name
+                  :notification-dispatcher #'ethersync--notification-dispatcher
                   :process socket-proc)))
     (process-put socket-proc 'jsonrpc-connection client)
     client))
+
+(defun ethersync--notification-dispatcher (client method params)
+  (message "received method=%s, params=%S"
+           (symbol-name method)
+           params))
 
 (defun ethersync--process-filter (proc string)
   "Called when new data STRING has arrived for PROC."

--- a/emacs-plugin/ethersync.el
+++ b/emacs-plugin/ethersync.el
@@ -1,0 +1,204 @@
+;;; ethersync.el --- ??? -*- lexical-binding: t -*-
+
+;; Author: Danny McClanahan
+;; Version: 0.0
+;; URL: https://github.com/ethersync/ethersync
+;; Package-Requires: ((emacs "25.2") (cl-lib "0.5") (dash "2"))
+;; Keywords: ???
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software: you can redistribute it and/or modify it under the terms of the
+;; GNU Affero General Public License as published by the Free Software Foundation, either version 3
+;; of the License, or (at your option) any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU Affero General Public License
+;; along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+;;; Commentary:
+
+;; ???
+
+
+;; Usage:
+
+;; ???
+
+
+;; License:
+
+;; AGPL 3.0+
+
+;; End Commentary
+
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'dash)
+(require 'jsonrpc)
+(require 'pcase)
+(require 'rx)
+(require 'subr-rx)
+
+
+;; Customization Helpers
+(defun ethersync--always-safe-local (_)
+  "Use as a :safe predicate in a `defcustom' form to accept any local override."
+  t)
+
+
+;; Public error types
+(define-error 'ethersync-error "Error using ethersync.")
+(define-error 'ethersync-client-connect-error "Error establishing a client connection"
+              'ethersync-error)
+(define-error 'ethersync-rpc-error "Error processing a json-rpc message."
+              '(jsonrpc-error ethersync-error))
+
+
+;; Customization
+(defgroup ethersync nil
+  "Group for `ethersync' customizations."
+  :group 'files
+  :group 'shadow)
+
+(defcustom ethersync-socket-location "/tmp/ethersync"
+  "File path to the unix domain socket used by ethersync."
+  :type 'file
+  :safe #'ethersync--always-safe-local
+  :group 'ethersync)
+
+
+;; Constants
+(defconst ethersync--process-name
+  "ethersync"
+  "Name of the network process to spawn with `make-network-process'.
+
+This name will be modified by `make-network-process' to make it unique, if multiple ethersync
+clients are spawned at once.")
+
+(defconst ethersync--connection-name
+  "ethersync-emacs-client"
+  "NAME argument for the `jsonrpc-connection' instance to spawn.")
+
+(defconst ethersync--process-buffer-name-base
+  " *ethersync-buf*"
+  "Base name of the buffer used for the network process.
+
+This name is used as the basis to generate a new buffer name for an ethersync client process.
+
+An initial space is used to hide the buffer from the buffer list.")
+
+
+;; Variables
+(defvar ethersync--active-clients nil
+  "The list of client processes currently active in the background.")
+
+
+;; Buffer-local Variables
+(defvar-local ethersync-controlling-client nil
+  "The ethersync client process making edits to this buffer, if applicable.")
+
+
+;; Class definitions
+(defclass ethersync-client (jsonrpc-connection)
+  ((-process
+    :initarg :process :type process :accessor ethersync--client-process
+    :documentation "Process object wrapped by this client."))
+  :documentation "An ethersync JSONRPC connection over a socket.
+The following initargs are accepted:
+
+:PROCESS (mandatory), a live network process object to a unix domain socket. The socket will be
+reading and writing JSONRPC messages with basic HTTP-style enveloping headers such as
+\"Content-Length:\".")
+
+(cl-defmethod initialize-instance :after ((client ethersync-client)
+                                          &key process &allow-other-keys)
+  (process-put process 'jsonrpc-connection client))
+
+(cl-defmethod ethersync--client-socket-path ((client ethersync-client))
+  "Retrieve the path to the unix domain socket being used by CLIENT."
+  (ethersync--get-process-socket-path
+   (ethersync--client-process client)))
+
+(cl-defmethod jsonrpc-connection-send ((client ethersync-client)
+                                       &key method params)
+  "Send a JSONRPC message with METHOD and PARAMS to connection CLIENT."
+  (cl-check-type method symbol "ethersync method name must be a symbol")
+  (let* ((args `(:method ,(symbol-name method) :params ,params))
+         (converted (jsonrpc-convert-to-endpoint client args 'notification))
+         (json (jsonrpc--json-encode converted))
+         (headers `(("Content-Length" . ,(format "%d" (string-bytes json))))))
+    (let ((proc (jsonrpc--process client))
+          (complete-encoded-message
+           (cl-loop for (header . value) in headers
+                    concat (concat header ": " value "\r\n") into header-section
+                    finally return (format "%s\r\n%s" header-section json))))
+      (process-send-string proc complete-encoded-message)
+      (jsonrpc--event
+       client 'client
+       :json json
+       :kind 'notification
+       :message args
+       :foreign-message converted))))
+
+
+;; Utilities
+(defun ethersync--get-file-mode (path)
+  (-> (file-attributes path)
+      (file-attribute-modes)
+      (aref 0)))
+
+(defun ethersync--file-is-socket (path)
+  (let ((mode (ethersync--get-file-mode path)))
+    (char-equal mode ?s)))
+
+(defun ethersync--assert-socket-path (socket-location)
+  (unless (file-exists-p socket-location)
+    (signal 'ethersync-client-connect-error
+            `("[ethersync] socket path does not exist" ,socket-location)))
+  (unless (ethersync--file-is-socket path)
+    (signal 'ethersync-client-connect-error
+            `("[ethersync] path is not a socket" ,socket-location))))
+
+(defun ethersync--get-process-socket-path (proc)
+  "Get the unix domain socket path used by PROC."
+  (cl-destructuring-bind (&key service &allow-other-keys)
+      (process-contact proc t)
+    (ethersync--assert-socket-path service)
+    service))
+
+
+;; Logic
+(defun ethersync--create-client-process (socket-location)
+  (ethersync--assert-socket-path socket-location)
+  (let* ((new-buffer-name (generate-new-buffer ethersync--process-buffer-name t))
+         (socket-proc (make-network-process
+                       :name ethersync--process-name
+                       :buffer new-buffer-name
+                       :service socket-location
+                       :family 'local
+                       :coding 'no-conversion
+                       :noquery t
+                       :filter #'ethersync--process-filter
+                       :sentinel #'ethersync--process-sentinel)))
+    (make-instance
+     'ethersync-client
+     :name ethersync--connection-name
+     :process socket-proc)))
+
+(defun ethersync--process-filter (proc string))
+
+(defun ethersync--process-sentinel (proc change))
+
+
+;; Autoloaded functions
+
+(provide 'ethersync)
+;;; ethersync.el ends here


### PR DESCRIPTION
Follow up from #77. This *would* be working and printing messages, but I have absolutely no idea how to get the daemon to write anything to the unix socket.

# Confusion on how to test
This section https://github.com/ethersync/ethersync/blob/main/docs/editor-plugin-dev-guide.md#seeing-what-an-existing-ethersync-plugin-sends which simply says to start up the neovim plugin is extremely opaque. I have tried using the `tools/dummy-jsonrpc.py` script:
```bash
> python ../tools/dummy-jsonrpc.py --message-type open "$(readlink -f playground/file.md)" | ./target/release/ethersync client --debug
```

And we get this output from the daemon itself:
```bash
21:02:04 DEBUG ThreadId(17) ethersync::daemon: Handling RevDelta from editor: RevisionedEditorTextDelta {
    revision: 0,
    delta: EditorTextDelta(
        [
            EditorTextOp {
                range: Range {
                    start: Position {
                        line: 0,
                        character: 0,
                    },
                    end: Position {
                        line: 0,
                        character: 0,
                    },
                },
                replacement: "hello, world",
            },
        ],
    ),
}
```

But for the life of me I have not been able to make the daemon write *to* the socket, such that reading from `/tmp/ethersync` with `socat` or `ethersync client` ever produces any output. I was able to get a local http peer attached, but that did not seem to produce any change.

I notice that when a file is changed after the daemon is killed, it notices this and prints out a warning when it is restarted. Is the daemon also supposed to be tracking changes made to files and sending them somewhere? It looks like there is code to watch for file change notifications--when is that activated? How does the daemon incorporate both editor changes as well as filesystem changes?

It seems like I don't understand the concept of [file ownership](https://github.com/ethersync/ethersync/blob/main/docs/editor-plugin-dev-guide.md#file-ownership). It's very much not clear to me how the daemon is supposed to be sending changes through it when writing to the stdin of `ethersync client` does not modify file contents, and modifying the file contents does not seem to get the daemon to write anything to the `/tmp/ethersync` socket.

I would really appreciate some more clarity on what "ownership" means, and I would particularly like to understand how to get the daemon to actually write anything to the socket, so I can actually test my editor integration. Or is the editor mostly supposed to be writing to the daemon? But then how does the editor receive inputs from others? Or is the editor supposed to be constantly refreshing the file from disk after the daemon modifies it? I assume not, but then how am I supposed to send input to the daemon so that it will send output to my editor?

I suppose I will be diving further into the rust code soon in order to figure all of this out. The editor plugin dev guide describes how to watch the daemon socket, but not how to get the daemon to actually write anything to the socket, except by telling the reader to execute the neovim plugin. I would appreciate an explanation of how to make the daemon write output to the socket so I can test my editor integration. Thanks.