### PR TITLE
Confirm plugin open in vim input test

### DIFF
--- a/vim-plugin/lua/utils.lua
+++ b/vim-plugin/lua/utils.lua
@@ -44,9 +44,6 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
         return
     end
 
-    if not vim.api.nvim_buf_is_loaded(bufnr) then
-        vim.fn.bufload(bufnr)
-    end
     vim.bo[bufnr].buflisted = true
 
     -- Fix reversed range and indexing each text_edits

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -109,12 +109,6 @@ local function track_edits(filename, uri)
         editor_revision = 0,
     }
 
-    -- Vim enables eol for an empty file, but we do use this option values
-    -- assuming there's a trailing newline iff eol is true.
-    if vim.fn.getfsize(vim.api.nvim_buf_get_name(0)) == 0 then
-        vim.bo.eol = false
-    end
-
     changetracker.track_changes(0, function(delta)
         files[filename].editor_revision = files[filename].editor_revision + 1
 
@@ -148,6 +142,13 @@ local function on_buffer_open()
     end
 
     local uri = "file://" .. filename
+
+    -- Vim enables eol for an empty file, but we do use this option values
+    -- assuming there's a trailing newline iff eol is true.
+    if vim.fn.getfsize(vim.api.nvim_buf_get_name(0)) == 0 then
+        vim.bo.eol = false
+    end
+
     send_request("open", { uri = uri }, function()
         track_edits(filename, uri)
     end)

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -1,5 +1,6 @@
 local changetracker = require("changetracker")
 local cursor = require("cursor")
+local debug = require("logging").debug
 
 -- JSON-RPC connection.
 local client
@@ -132,6 +133,7 @@ end
 -- Forward buffer edits to daemon as well as subscribe to daemon events ("open").
 local function on_buffer_open()
     local filename = vim.fn.expand("%:p")
+    debug("on_buffer_open: " .. filename)
 
     if not is_ethersync_enabled(filename) then
         return
@@ -150,12 +152,14 @@ local function on_buffer_open()
     end
 
     send_request("open", { uri = uri }, function()
+        debug("Tracking Edits")
         track_edits(filename, uri)
     end)
 end
 
 local function on_buffer_close()
     local closed_file = vim.fn.expand("<afile>:p")
+    debug("on_buffer_close: " .. closed_file)
 
     if not is_ethersync_enabled(closed_file) then
         return


### PR DESCRIPTION
#110  has introduced a subtle bug. `open`ing a buffer always had a couple of side-effects that the tests are relying on. Now we need to acknowledge the `open` from the daemon (as we're, as of #110, only actually doing things in the plugin if the `open` was successful):
- starting the changetracker
- setting the correct EOL value

Additionally there seems to be an unexpected state: Through logging I have observed that when we open a buffer via the nvim library, it doesn't seem to be "loaded". When adding logging, it's possible to see that editing the file opens the buffer again. Probably through [this line](https://github.com/ethersync/ethersync/blob/fix-vim-tests/vim-plugin/lua/utils.lua#L48)?