### PR TITLE
make --socket-path pull ETHERSYNC_SOCKET from env via clap

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -7,7 +7,7 @@ default-run = "ethersync"
 
 [dependencies]
 serde_json = { version = "1" }
-clap = { version = "4.5.3", features = ["derive"] }
+clap = { version = "4.5.3", features = ["derive", "env"] }
 automerge = "0.5.9"
 rand = "0.8.5"
 tokio = { version = "1", features = ["full"] }

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -66,11 +66,6 @@ local function connect()
 
     local params = { "client" }
 
-    local socket_path = os.getenv("ETHERSYNC_SOCKET")
-    if socket_path then
-        table.insert(params, "--socket-path=" .. socket_path)
-    end
-
     local dispatchers = {
         notification = function(method, notification_params)
             process_operation_for_editor(method, notification_params)


### PR DESCRIPTION
# Problem
It's much easier to set `ETHERSYNC_SOCKET` via the environment for many use cases instead of modifying the command line, as noted by @zormit in https://github.com/ethersync/ethersync/pull/112#issuecomment-2287008800. We currently do this by hand in the nvim plugin: https://github.com/ethersync/ethersync/blob/a41304aa0543077bcf8908d912dabf8bc91069cf/vim-plugin/plugin/ethersync.lua#L69-L72

We could do the same for the emacs plugin in #112, but it might be nice for the `ethersync` binary to support this itself.

# Solution
- Add `"env"` feature to our `clap` dependency.
- Set [`Arg::env()`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.env) for the global `socket_path: PathBuf` argument.
    - A command-line `--socket-path` argument overrides this value; the env var is only read if the argument is not provided.
    - *Note that the daemon is now also affected by `ETHERSYNC_SOCKET` in addition to the client.*
- Remove code in nvim plugin to translate the `ETHERSYNC_SOCKET` env var into `--socket-path`.

# Result
All editor plugins (and the fuzzer) can expect to be able to set the `ETHERSYNC_SOCKET` environment variable as a separate way to parameterize the ethersync client, and users can set `ETHERSYNC_SOCKET` in their environment when invoking the daemon.