### PR TITLE
add optimization flags to --release profile

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -44,3 +44,22 @@ rust-ini = "0.21.1"
 assert_matches = "1.5"
 serial_test = "3.1.1"
 tracing-test = "0.2.4"
+
+[profile.release]
+# Stripping symbols (not debuginfo) reduces binary size by ~1.5x.
+strip = true
+opt-level = 3
+
+# 2-3x slower to compile, but produces a ~1.2x smaller binary.
+# TODO: benchmark this!
+[profile.release-lto]
+inherits = "release"
+lto = true
+codegen-units = 1
+
+# Also quite slow to compile, but produces a ~1.6x smaller binary.
+[profile.release-size]
+inherits = "release"
+lto = true
+codegen-units = 1
+opt-level = "s"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -45,13 +45,16 @@ assert_matches = "1.5"
 serial_test = "3.1.1"
 tracing-test = "0.2.4"
 
-[profile.release]
 # Stripping symbols (not debuginfo) reduces binary size by ~1.5x.
+# This is the default profile for `cargo install`:
+# https://doc.rust-lang.org/cargo/reference/profiles.html#profile-selection.
+# TODO: We may want to make [profile.release-size] the default
+# once we're out of the fast iteration development phase.
+[profile.release]
 strip = true
 opt-level = 3
 
 # 2-3x slower to compile, but produces a ~1.2x smaller binary.
-# TODO: benchmark this!
 [profile.release-lto]
 inherits = "release"
 lto = true


### PR DESCRIPTION
It's possible to set [optimization flags](https://doc.rust-lang.org/cargo/reference/profiles.html) in cargo for the `--release` profile. This may make it slightly faster, and symbol stripping drastically reduces binary size (14M -> 7.2M):
```shell
> git checkout main
> cargo build --release
> ls target/release/ethersync
-rwxr-xr-x 2 cosmicexplorer wheel 14M Aug 14 08:14 target/release/ethersync*
> git checkout -
> cargo build --release
> ls target/release/ethersync
-rwxr-xr-x 2 cosmicexplorer wheel 7.2M Aug 14 08:08 target/release/ethersync*
```

Note that `opt-level` is [already set to 3 by default](https://doc.rust-lang.org/cargo/reference/profiles.html#release).