### PR TITLE
Rename flake outputs, to better adhere to nixpkgs naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Again, we have several options of how to install it:
   For testing purposes, you can run an Ethersync-enabled Neovim like this:
 
   ```bash
-  nix run github:ethersync/ethersync#neovim
+  nix run github:ethersync/ethersync#neovim-with-ethersync
   ```
 </details>
 

--- a/flake.nix
+++ b/flake.nix
@@ -31,16 +31,20 @@
       ethersync = (final.callPackage naersk {}).buildPackage {
         src = ./daemon;
       };
-      neovim-plugin = final.vimUtils.buildVimPlugin {
-        name = "ethersync";
-        src = ./vim-plugin;
-      };
-      neovim = let
+      vimPlugins =
+        prev.vimPlugins
+        // {
+          nvim-ethersync = final.vimUtils.buildVimPlugin {
+            name = "ethersync";
+            src = ./vim-plugin;
+          };
+        };
+      neovim-with-ethersync = let
         nvim-custom = prev.neovim.override {
           configure = {
             packages.plugins = {
               start = [
-                neovim-plugin
+                vimPlugins.nvim-ethersync
               ];
             };
             # In Nix' standard environment, we can't write to $HOME, so we need to
@@ -59,8 +63,8 @@
       inherit
         (pkgs)
         ethersync
-        neovim-plugin
-        neovim
+        nvim-ethersync
+        neovim-with-ethersync
         ;
       default = ethersync;
     });


### PR DESCRIPTION
As suggested by @mangoiv: https://github.com/ethersync/ethersync/issues/132#issuecomment-2288620383