### PR TITLE
Support Neovim >=0.7

### DIFF
--- a/book/src/neovim.md
+++ b/book/src/neovim.md
@@ -1,9 +1,5 @@
 # Neovim Plugin
 
-> ❗ **Important**
->
-> The plugin currently requires Neovim v0.10.
-
 Again, we have several options of how to install the Neovim plugin:
 
 ## Lazy

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -94,7 +94,20 @@ end
 
 local function is_ethersync_enabled(filename)
     -- Recusively scan up directories. If we find an .ethersync directory on any level, return true.
-    return vim.fs.root(filename, ".ethersync") ~= nil
+    if vim.version().api_level < 12 then
+        -- In Vim 0.9, do it manually.
+        local path = filename
+        while path ~= "/" do
+            if vim.fn.isdirectory(path .. "/.ethersync") == 1 then
+                return true
+            end
+            path = vim.fn.fnamemodify(path, ":h")
+        end
+        return false
+    else
+        -- In Vim 0.10, this function is available.
+        return vim.fs.root(filename, ".ethersync") ~= nil
+    end
 end
 
 local function track_edits(filename, uri)


### PR DESCRIPTION
The thing blocking us from using olding Neovim versions now are the `nvim_create_autocmd` functions.

Neovim v0.7 (the minimum required version) was released over three years ago in April 2022.

Lazy, for example, requires v8.0.

Fixes #56.