### PR TITLE
Make "edit" messages contain revision and delta on the top level

### DIFF
--- a/book/src/editor-plugin-dev-guide.md
+++ b/book/src/editor-plugin-dev-guide.md
@@ -55,10 +55,6 @@ The protocol uses a couple of basic data types (we're using the same syntax to s
 
     A complex text manipulation, similar to LSP's [`TextEdit[]`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEditArray). Like in LSP, **all ranges refer to the starting content**, and must never overlap, see the linked LSP documentation.
 
-- `RevisionedDelta: {delta: Delta, revision: number}`
-
-    This attaches a revision number to a delta. The semantics are that the delta *applies to* (is intended for) that specified revision.
-
 ### Messages sent by the editor to the daemon
 
 These should be sent as JSON-RPC requests, so that the daemon can send back errors.
@@ -73,11 +69,11 @@ These should be sent as JSON-RPC requests, so that the daemon can send back erro
 
 - Sent when the editor closes the file. It is no longer interested in receiving updates.
 
-#### `"edit" {uri: DocumentUri, delta: RevisionedDelta}`
+#### `"edit" {uri: DocumentUri, revision: number, delta: Delta}`
 
 - Sent when the user edits an open document, or when the text editor makes a change to a text buffer content for any reason.
 - **Pitfall:** Make sure to not send these messages when you incorporate a remote edit into the buffer content. You have to find a way to filter out the edits you cause as a plugin, for example, by setting a temporary ignore flag while the edit is being made, or by remembering which edits you perform, and checking against them when the editor notifies you of a buffer change.
-- The `revision` attribute of `RevisionedDelta` is the last revision seen from the daemon.
+- The `revision` is the last revision seen from the daemon. This means that this edit is *intended for* that daemon revision.
 - After each user edit, the editor must increase its editor revision.
 
 #### `"cursor" {uri: DocumentUri, ranges: Range[]}`
@@ -88,9 +84,9 @@ These should be sent as JSON-RPC requests, so that the daemon can send back erro
 
 These should be sent as notifications, there is no need to reply to them.
 
-#### `"edit" {uri: DocumentUri, delta: RevisionedDelta}`
+#### `"edit" {uri: DocumentUri, revision: number, delta: Delta}`
 
-- `revision` in the `RevisionedDelta` is the last revision the daemon has seen from the editor.
+- `revision` is the last revision the daemon has seen from the editor.
 - If this is not the editor revision stored in the editor, the editor must ignore the edit. The daemon will send an updated version later.
 - After applying the received edit, the editor must increase its daemon revision.
 

--- a/daemon/integration-tests/tests/vim-plugin.rs
+++ b/daemon/integration-tests/tests/vim-plugin.rs
@@ -4,7 +4,6 @@ use ethersync::sandbox;
 use ethersync::types::{
     factories::*, EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor,
     EditorProtocolObject, EditorTextDelta, EditorTextOp, JSONRPCFromEditor,
-    RevisionedEditorTextDelta,
 };
 
 use pretty_assertions::assert_eq;
@@ -145,13 +144,10 @@ async fn assert_vim_deltas_yield_content(
     socket.acknowledge_open().await;
 
     for op in &deltas {
-        let rev_editor_delta = RevisionedEditorTextDelta {
-            revision: 0,
-            delta: EditorTextDelta(vec![op.clone()]),
-        };
         let editor_message = EditorProtocolMessageToEditor::Edit {
             uri: format!("file://{}", file_path.display()),
-            delta: rev_editor_delta,
+            revision: 0,
+            delta: EditorTextDelta(vec![op.clone()]),
         };
         let payload = EditorProtocolObject::Request(editor_message)
             .to_jsonrpc()
@@ -243,7 +239,7 @@ async fn assert_vim_input_yields_replacements(
                         ..
                     } = message else {continue;};
                     let expected_replacement = expected_replacements.remove(0);
-                    let operations = delta.delta.0;
+                    let operations = delta.0;
                     assert_eq!(vec![expected_replacement], operations, "Different replacements when applying input '{}' to content '{:?}'", input, initial_content);
                 }
             })

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -155,7 +155,8 @@ pub enum EditorProtocolMessageFromEditor {
     },
     Edit {
         uri: DocumentUri,
-        delta: RevisionedEditorTextDelta,
+        revision: usize,
+        delta: EditorTextDelta,
     },
     Cursor {
         uri: DocumentUri,
@@ -271,7 +272,8 @@ impl EditorProtocolObject {
 pub enum EditorProtocolMessageToEditor {
     Edit {
         uri: DocumentUri,
-        delta: RevisionedEditorTextDelta,
+        revision: usize,
+        delta: EditorTextDelta,
     },
     Cursor {
         userid: CursorId,

--- a/tools/dummy-jsonrpc.py
+++ b/tools/dummy-jsonrpc.py
@@ -28,18 +28,16 @@ messages = {
         "id": 2,
         "params": {
             "uri": uri,
-            "delta": {
-                "revision": 0,
-                "delta": [
-                    {
-                        "range": {
-                            "start": {"line": 0, "character": 0},
-                            "end": {"line": 0, "character": 0},
-                        },
-                        "replacement": "hello, world",
-                    }
-                ],
-            },
+            "revision": 0,
+            "delta": [
+                {
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 0},
+                    },
+                    "replacement": "hello, world",
+                }
+            ],
         },
     },
 }

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -38,8 +38,8 @@ local function process_operation_for_editor(method, parameters)
         local uri = parameters.uri
         -- TODO: Determine the proper filepath (relative to project dir).
         local filepath = vim.uri_to_fname(uri)
-        local delta = parameters.delta.delta
-        local the_editor_revision = parameters.delta.revision
+        local delta = parameters.delta
+        local the_editor_revision = parameters.revision
 
         -- Check if operation is up-to-date to our content.
         -- If it's not, ignore it! The daemon will send a transformed one later.
@@ -126,12 +126,7 @@ local function track_edits(filename, uri)
     changetracker.track_changes(0, function(delta)
         files[filename].editor_revision = files[filename].editor_revision + 1
 
-        local rev_delta = {
-            delta = delta,
-            revision = files[filename].daemon_revision,
-        }
-
-        local params = { uri = uri, delta = rev_delta }
+        local params = { uri = uri, delta = delta, revision = files[filename].daemon_revision }
 
         send_request("edit", params)
     end)


### PR DESCRIPTION
This makes both creating and consuming the "edit" messages easier.