### PR TITLE
Bump daemon version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.5.0 (2024-09-30)
+
+Breaking changes:
+
+- "edit" messages now contain the revision and the delta on the top level, to avoid unnecessary nesting.
+
+New features:
+
+- We have installable packages on crates.io and on the Arch User Repository.
+- Lower mimimum supported Neovim version from 0.10 to 0.7.
+- Released a VS Code plugin!
+- When there is no persisted CRDT document, load a structure that's compatible with other peers. This allows peers to start up individually, and sync up later.
+- Persist changes to CRDT incrementally, instead of saving the entire document each time. This gives a big performance boost.
+
+Bug fixes:
+
+- Does not crash when binary files exist by ignoring them.
+
 # 0.4.0 (2024-09-13)
 
 New features:

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethersync"
 description = "Enables real-time co-editing of local text files."
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Moritz Neeb <nt4u@kpvn.de>", "blinry <mail@blinry.org>"]
 license = "AGPL-3.0-or-later"
 readme = "../README.md"

--- a/daemon/integration-tests/Cargo.lock
+++ b/daemon/integration-tests/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "ethersync"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "automerge",

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ethersync",
     "displayName": "Ethersync",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "publisher": "ethersync",
     "description": "Editor-agnostic real-time collaborative editing of local text files.",
     "contributors": [


### PR DESCRIPTION
# 0.5.0 (2024-09-30)

Breaking changes:

- "edit" messages now contain the revision and the delta on the top level, to avoid unnecessary nesting.

New features:

- We have installable packages on crates.io and on the Arch User Repository.
- Lower mimimum supported Neovim version from 0.10 to 0.7.
- Released a VS Code plugin!
- When there is no persisted CRDT document, load a structure that's compatible with other peers. This allows peers to start up individually, and sync up later.
- Persist changes to CRDT incrementally, instead of saving the entire document each time. This gives a big performance boost.

Bug fixes:

- Does not crash when binary files exist by ignoring them.