### PR TITLE
Make sure the socket can't be accessed by other users

### DIFF
--- a/daemon/integration-tests/README.md
+++ b/daemon/integration-tests/README.md
@@ -6,11 +6,11 @@ This directory contains integration tests for Ethersync. They assume that your `
 To run all integration tests, run:
 
 ```bash
-ethersync test
+cargo test
 ```
 
 To run only a specific integration test, run:
 
 ```bash
-ethersync test --test <name>
+cargo test --test <name>
 ```

--- a/daemon/src/sandbox.rs
+++ b/daemon/src/sandbox.rs
@@ -158,6 +158,7 @@ fn absolute_and_canonicalized(path: &Path) -> Result<PathBuf> {
         }
     }
 
+    // TODO: can we handle this expect more graceful? Or log more information when crashing?
     let mut canonical_path = prefix_path.canonicalize().expect("Could not canonicalize");
     if suffix_path.components().count() != 0 {
         canonical_path = canonical_path.join(suffix_path);

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723637854,
-        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "lastModified": 1732521221,
+        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
         "type": "github"
       },
       "original": {
@@ -18,14 +18,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "parts": {
@@ -33,11 +33,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
We do this by making sure that the directory containing the socket is only accessible by the current user. The default directory is $XDG_RUNTIME_DIR.

Rename --socket-path to --socket-name.

Fixes #241.