### PR TITLE
Remove the --secret command line argument for security reasons

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -7,15 +7,16 @@ There are two ways to configure what an Ethersync daemon will do.
 You can provide the options on the command line, after `ethersync daemon`:
 
 - `--peer <multiaddr>` specifies which peer you want to try connect to.
-- `--secret <passphrase>` specifies the shared secret passphrase. Peers must use the same passphrase to be allowed to connect.
 - `--port <port for your daemon>` specifies which port the daemon should listen for incoming connections.
+
+For security reasons, it is not possible to provide the secret via a command line flag.
 
 ## Configuration files
 
-If you keep starting Ethersync with the same options, you can also put any of these options into a configuration file at `.ethersync/config`:
+If you keep starting Ethersync with the same options, you can also put the following options into a configuration file at `.ethersync/config`. Here, you have the option to specify a secret; otherwise, a default password will be used, which is only recommended for testing:
 
 ```ini
 peer = <multiaddr you want to try connecting to>
-secret = <the shared secret>
 port = <port for your daemon>
+secret = <the shared secret>
 ```

--- a/book/src/pair-programming.md
+++ b/book/src/pair-programming.md
@@ -33,22 +33,21 @@ To start the session, run:
 ethersync daemon
 ```
 
-This will print, among other initialization information, two things you need to tell the other peers:
+This will print, among other initialization information, the [multiaddress](connection-making.md#multiaddress) which looks like `/ip4/192.168.23.42/tcp/58063/p2p/12D3KooWPNj7mom3X2D6NiSyxbFa5hHfzxDFP98ZL52yYnkEVmDv`.
 
-- The [multiaddress](connection-making.md#multiaddress) which looks like `/ip4/192.168.23.42/tcp/58063/p2p/12D3KooWPNj7mom3X2D6NiSyxbFa5hHfzxDFP98ZL52yYnkEVmDv`.
-- A secret passphrase, that is randomly generated each time you start the daemon. If you want to use a stable secret, we recommend putting it into the [configuration file](configuration.md).
+You need to share this with the other peers.
 
 ### 4. Other peers
 
 To join a session, run:
 
 ```bash
-ethersync demon --peer <multiaddr> --secret <secret>
+ethersync demon --peer <multiaddr>
 ```
 
 This should show you a message like "Connected to peer ...". The hosting daemon should show a message like "Peer connected".
 
-If you prefer, it's also possible to use the [configuration file](configuration.md) to provide multiaddress and secret.
+ When used "in production" it's also possible and recommended to use the [configuration file](configuration.md) to provide the multiaddress and a secret for encryption.
 
 ### 5. Collaborate!
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -8,6 +8,7 @@ use tracing::{error, info};
 
 mod jsonrpc_forwarder;
 
+// TODO: Define these constants in the ethersync crate, and use them here.
 const DEFAULT_SOCKET_NAME: &str = "ethersync";
 const ETHERSYNC_CONFIG_DIR: &str = ".ethersync";
 const ETHERSYNC_CONFIG_FILE: &str = "config";
@@ -43,9 +44,6 @@ enum Commands {
         /// Port to listen on as a hosting peer [default: assigned by OS].
         #[arg(long)]
         port: Option<u16>,
-        /// Shared secret passphrase to use for mutual authorization.
-        #[arg(long)]
-        secret: Option<String>,
         /// Initialize the current contents of the directory as a new Ethersync directory.
         #[arg(long)]
         init: bool,
@@ -84,7 +82,6 @@ async fn main() -> Result<()> {
             directory,
             peer,
             port,
-            secret,
             init,
         } => {
             if matches.value_source("socket_name").unwrap() == ValueSource::EnvVariable {
@@ -110,10 +107,12 @@ async fn main() -> Result<()> {
                 return Ok(());
             }
 
+            // There's the option to put a user provided passphrase here, which is disabled for
+            // now until we code a more secure way for user to provide it.
             let mut peer_connection_info = PeerConnectionInfo {
                 peer,
                 port,
-                passphrase: secret,
+                passphrase: None,
             };
 
             let config_file = directory

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -101,7 +101,7 @@ impl P2PActor {
             .unwrap_or(DEFAULT_PASSPHRASE.to_string());
         let is_default_passphrase = passphrase == DEFAULT_PASSPHRASE;
         if is_default_passphrase {
-            warn!("\n\n\tSECURITY WARNING: Running without a secret is only recommended when trying out this software locally.\n\tYou can provide one with --secret, or put secret = <secret> in .ethersync/config.\n");
+            warn!("\n\n\tSECURITY WARNING: Running without a secret is only recommended when trying out this software locally.\n\tYou can put secret = <secret> in .ethersync/config.\n");
         }
         let mut swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)
             .with_tokio()
@@ -164,7 +164,7 @@ impl P2PActor {
                         let secret_parameter = if is_default_passphrase {
                             ""
                         } else {
-                            " --secret <your secret>"
+                            " (They need put secret = <your-secret> in the .ethersync/config file.)"
                         };
                         info!(
                             "Others can connect with:\n\n\tethersync daemon --peer {}{}\n",


### PR DESCRIPTION
Using it will leak the secret with other users on the same system. The only way to provide a secret now is via the config file.