### PR TITLE
When a connection times out, reconnect

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -1243,6 +1243,7 @@ dependencies = [
  "serde",
  "serde_json",
  "temp-dir",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-util",

--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -361,9 +361,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1221,6 +1221,7 @@ name = "ethersync"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "automerge",
  "clap",
  "constant_time_eq",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -58,6 +58,7 @@ ropey = "1.6.1"
 rust-ini = "0.21.1"
 serde = { version = "1.0.198", features = ["derive"] }
 serde_json = "1"
+thiserror = "2.0.12"
 time = { version = "0.3.36", features = ["formatting"] }
 tokio-util = { version = "0.7.11", features = ["codec"] }
 tracing = "0.1.40"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -36,6 +36,7 @@ required-features = ["executable-deps"]
 
 [dependencies]
 anyhow = "1.0.81"
+async-trait = "0.1.88"
 automerge = "0.6.1"
 clap = { version = "4.5.3", features = ["derive", "env"], optional = true }
 constant_time_eq = "0.3.1"

--- a/daemon/integration-tests/Cargo.lock
+++ b/daemon/integration-tests/Cargo.lock
@@ -1148,6 +1148,7 @@ name = "ethersync"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "automerge",
  "constant_time_eq",
  "derive_more 2.0.1",
@@ -1166,6 +1167,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-util",

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -922,7 +922,7 @@ impl Daemon {
             spawn_persister(document_handle.clone()).await;
         }
 
-        // Start p2p listener.
+        // Start connection manager.
         let connection_manager = peer::ConnectionManager::new(document_handle.clone(), &base_dir)
             .await
             .expect("Failed to start connection manager");

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! A peer is another daemon. This module is all about daemon to daemon communication.
+//! This module provides a ConnectionManager, which can be used to connect to other daemons.
 
 use self::sync::SyncActor;
 use crate::daemon::DocumentActorHandle;
@@ -157,11 +157,16 @@ impl ConnectionManager {
 enum EndpointMessage {
     // Instruct the endpoint to connect to a new peer.
     Connect {
+        // All information we need to connect to another peer.
         secret_address: SecretAddress,
+        // On connection success, this channel will be pinged.
+        // Used for the initial connection, where we want to fail if connecting fails.
         response_tx: Option<oneshot::Sender<Result<()>>>,
     },
 }
 
+// Owns the Iroh endpoint, accepts incoming connections, and can be instructed to connect to
+// another daemon.
 struct EndpointActor {
     endpoint: iroh::Endpoint,
     message_rx: mpsc::Receiver<EndpointMessage>,

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -245,7 +245,10 @@ impl EndpointActor {
         message_tx: mpsc::Sender<EndpointMessage>,
         secret_address: SecretAddress,
     ) -> Result<()> {
-        info!("Connection to peer TODO lost, trying to reconnect...");
+        info!(
+            "Connection to peer {} lost, trying to reconnect...",
+            secret_address.node_addr.node_id
+        );
         // We don't need to be notified, so we don't need to use the response channel.
         message_tx
             .send(EndpointMessage::Connect {
@@ -322,8 +325,6 @@ impl EndpointActor {
         // The syncer can fail when the protocol_handler below has
         // stopped. But in that case, both components will stop, so we can
         // ignore the error.
-        if let Err(e) = syncer.run().await {
-            error!("Syncing failed with: {e}");
-        }
+        let _ = syncer.run().await;
     }
 }

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -18,7 +18,7 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 use std::str::FromStr;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 mod sync;
 
@@ -299,7 +299,7 @@ impl EndpointActor {
                                     self.handle_incoming_connection(conn);
                                 }
                                 Err(err) => {
-                                    error!("Error while accepting peer connection: {err}");
+                                    debug!("Error while accepting peer connection: {err}");
                                 }
                             }
                         }

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -317,7 +317,6 @@ impl EndpointActor {
         let connection = IrohConnection::new(conn, auth)
             .await
             .expect("Failed to authenticate connection");
-        dbg!("authed");
         let syncer = SyncActor::new(document_handle, Box::new(connection));
 
         // The syncer can fail when the protocol_handler below has

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -18,7 +18,7 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 use std::str::FromStr;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 mod sync;
 
@@ -231,15 +231,24 @@ impl EndpointActor {
                 let document_handle_clone = self.document_handle.clone();
                 let message_tx_clone = self.message_tx.clone();
                 tokio::spawn(async move {
-                    Self::handle_peer(
+                    // handle_peer currently only returns an error if authentication fails.
+                    // In this case, we don't want to reconnect, but panic!
+                    match Self::handle_peer(
                         document_handle_clone,
                         conn,
                         PeerAuth::YourPassphrase(secret_address.passphrase.clone()),
                     )
-                    .await;
-                    Self::reconnect(message_tx_clone, secret_address)
-                        .await
-                        .expect("Failed to initiate reconnection");
+                    .await
+                    {
+                        Ok(()) => {
+                            Self::reconnect(message_tx_clone, secret_address)
+                                .await
+                                .expect("Failed to initiate reconnection");
+                        }
+                        Err(err) => {
+                            panic!("Making a connection failed: {err}");
+                        }
+                    }
                 });
             }
         }
@@ -310,12 +319,15 @@ impl EndpointActor {
         let my_passphrase_clone = self.my_passphrase.clone();
         let document_handle_clone = self.document_handle.clone();
         tokio::spawn(async move {
-            Self::handle_peer(
+            if let Err(err) = Self::handle_peer(
                 document_handle_clone,
                 conn,
                 PeerAuth::MyPassphrase(my_passphrase_clone),
             )
-            .await;
+            .await
+            {
+                warn!("Incoming connection failed: {err}");
+            }
 
             info!("Peer disconnected: {node_id}",);
         });
@@ -325,16 +337,11 @@ impl EndpointActor {
         document_handle: DocumentActorHandle,
         conn: iroh::endpoint::Connection,
         auth: PeerAuth,
-    ) {
-        let connection = IrohConnection::new(conn, auth)
-            .await
-            .expect("Failed to authenticate connection");
+    ) -> Result<()> {
+        let connection = IrohConnection::new(conn, auth).await?;
         let syncer = SyncActor::new(document_handle, Box::new(connection));
-
-        // The syncer can fail when the protocol_handler below has
-        // stopped. But in that case, both components will stop, so we can
-        // ignore the error.
         let _ = syncer.run().await;
+        Ok(())
     }
 }
 

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -5,21 +5,19 @@
 
 //! A peer is another daemon. This module is all about daemon to daemon communication.
 
-use crate::daemon::{DocMessage, DocumentActorHandle};
-use crate::types::EphemeralMessage;
-use anyhow::{bail, Context, Result};
-use automerge::sync::{Message as AutomergeSyncMessage, State as SyncState};
+use self::sync::SyncActor;
+use crate::daemon::DocumentActorHandle;
+use anyhow::{bail, Result};
 use iroh::{NodeAddr, SecretKey};
-use postcard::{from_bytes, to_allocvec};
-use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
-use std::mem;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 use std::str::FromStr;
-use tokio::sync::{broadcast, mpsc, oneshot};
-use tracing::{debug, error, info, warn};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, error, info};
+
+mod sync;
 
 const ALPN: &[u8] = b"/ethersync/0";
 
@@ -44,16 +42,6 @@ impl FromStr for SecretAddress {
             passphrase,
         })
     }
-}
-
-#[derive(Deserialize, Serialize)]
-/// The PeerMessage is used for peer to peer data exchange.
-enum PeerMessage {
-    /// The Sync message contains the changes to the CRDT
-    Sync(Vec<u8>),
-    /// The Ephemeral message currently is used for cursor messages, but can later be used for
-    /// other things that should not be persisted.
-    Ephemeral(EphemeralMessage),
 }
 
 pub struct ConnectionManager {
@@ -341,7 +329,7 @@ impl EndpointActor {
 
         // This is a function that either runs forever, or errors.
         // But errors just mean that the connection was closed/interrupted, so we ignore them.
-        let _ = Self::protocol_handler(
+        let _ = sync::protocol_handler(
             conn,
             from_peer_tx,
             to_peer_rx,
@@ -353,190 +341,5 @@ impl EndpointActor {
         // TODO: Do we still this abort? The syncer should stop anyway once it cannot use its
         // to_peer_tx anymore.
         syncer_handle.abort_handle().abort();
-    }
-
-    /// Core low-level syncing protocol.
-    async fn protocol_handler(
-        conn: iroh::endpoint::Connection,
-        from_peer_tx: mpsc::Sender<PeerMessage>,
-        mut to_peer_rx: mpsc::Receiver<PeerMessage>,
-        my_passphrase: SecretKey,
-        peer_passphrase: Option<SecretKey>,
-    ) -> Result<()> {
-        let (mut send, mut recv) = if let Some(peer_passphrase) = peer_passphrase {
-            let (mut send, recv) = conn.open_bi().await?;
-
-            send.write_all(&peer_passphrase.to_bytes()).await?;
-
-            (send, recv)
-        } else {
-            let (send, mut recv) = conn.accept_bi().await?;
-
-            let mut received_passphrase = [0; 32];
-            recv.read_exact(&mut received_passphrase).await?;
-
-            // Guard against timing attacks.
-            if !constant_time_eq::constant_time_eq(&received_passphrase, &my_passphrase.to_bytes())
-            {
-                warn!("Peer provided incorrect passphrase.");
-                return Ok(());
-            }
-
-            (send, recv)
-        };
-
-        loop {
-            let mut message_len_buf = [0; 4];
-
-            tokio::select! {
-                message_maybe = to_peer_rx.recv() => {
-                    match message_maybe {
-                        Some(message) => {
-                            let bytes: Vec<u8> = to_allocvec(&message)?;
-                            let byte_count = u32::try_from(bytes.len());
-                            send
-                                .write_all(&byte_count?.to_be_bytes())
-                                .await?;
-                            send
-                                .write_all(&bytes)
-                                .await?;
-                            }
-                        None => {
-                            // TODO: What should we do?
-                            error!("None on to_peer_rx");
-                        }
-                    }
-                }
-                _ = recv.read_exact(&mut message_len_buf) => {
-                    let byte_count = u32::from_be_bytes(message_len_buf);
-                    let mut bytes = vec![0; byte_count as usize];
-                    recv.read_exact(&mut bytes).await?;
-
-                    let message = from_bytes(&bytes)?;
-
-                    from_peer_tx.send(message).await?;
-                }
-            }
-        }
-    }
-}
-
-/// Transport-agnostic logic of how to sync with another peer.
-/// Receives Automerge sync messages on one channel, and sends some out on another.
-/// Maintains the sync state, and communicates with the document.
-struct SyncActor {
-    peer_state: SyncState,
-    document_handle: DocumentActorHandle,
-    syncer_receiver: mpsc::Receiver<PeerMessage>,
-    syncer_sender: mpsc::Sender<PeerMessage>,
-}
-
-impl SyncActor {
-    fn new(
-        document_handle: DocumentActorHandle,
-        syncer_receiver: mpsc::Receiver<PeerMessage>,
-        syncer_sender: mpsc::Sender<PeerMessage>,
-    ) -> Self {
-        Self {
-            peer_state: SyncState::new(),
-            document_handle,
-            syncer_receiver,
-            syncer_sender,
-        }
-    }
-
-    async fn receive_peer_message(&mut self, message: PeerMessage) -> Result<()> {
-        let (reponse_tx, response_rx) = oneshot::channel();
-        match message {
-            PeerMessage::Sync(message_buf) => {
-                let message = AutomergeSyncMessage::decode(&message_buf)?;
-                self.document_handle
-                    .send_message(DocMessage::ReceiveSyncMessage {
-                        message,
-                        state: mem::take(&mut self.peer_state),
-                        response_tx: reponse_tx,
-                    })
-                    .await;
-                self.peer_state = response_rx
-                    .await
-                    .expect("Couldn't read response from Document channel");
-            }
-            PeerMessage::Ephemeral(cursor) => {
-                self.document_handle
-                    .send_message(DocMessage::ReceiveEphemeral(cursor))
-                    .await;
-            }
-        }
-        Ok(())
-    }
-
-    async fn generate_sync_message(&mut self) -> Result<()> {
-        let (reponse_tx, response_rx) = oneshot::channel();
-        self.document_handle
-            .send_message(DocMessage::GenerateSyncMessage {
-                state: mem::take(&mut self.peer_state),
-                response_tx: reponse_tx,
-            })
-            .await;
-        let (ps, message) = response_rx
-            .await
-            .context("Could not read response from Document channel")?;
-        self.peer_state = ps;
-        if let Some(message) = message {
-            self.syncer_sender
-                .send(PeerMessage::Sync(message.encode()))
-                .await
-                .context("Failed to send sync message on syncer_sender channel")?;
-        }
-        Ok(())
-    }
-
-    async fn run(mut self) -> Result<()> {
-        let mut doc_changed_ping_rx = self.document_handle.subscribe_document_changes();
-        let mut ephemeral_messages_rx = self.document_handle.subscribe_ephemeral_messages();
-
-        // Kick off initial synchronization with peer.
-        self.generate_sync_message().await?;
-
-        loop {
-            tokio::select! {
-                // As doc_changed_ping_rx is a broadcast channel our understanding is,
-                // that this breaks a potential cyclic deadlock between SyncerActor
-                // and TCPActor (e.g. when TCPWriteActor.send blocks).
-                doc_ping = doc_changed_ping_rx.recv() => {
-                    match doc_ping {
-                        Ok(()) => { self.generate_sync_message().await?; }
-                        Err(broadcast::error::RecvError::Closed) => {
-                            panic!("Doc changed channel has been closed");
-                        }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {
-                            // This is fine, the messages in this channel are just pings.
-                            // It's fine if we miss some.
-                            debug!("Doc changed ping channel lagged (this is probably fine).");
-                        }
-                    }
-                }
-                ephemeral_message = ephemeral_messages_rx.recv() => {
-                    match ephemeral_message {
-                        Ok(ephemeral_message) => {
-                            self.syncer_sender.send(PeerMessage::Ephemeral(ephemeral_message))
-                                .await
-                                .context("Failed to send ephemeral message on syncer_sender channel")?;
-                        }
-                        Err(broadcast::error::RecvError::Closed) => {
-                            panic!("Ephemeral message channel has been closed");
-                        }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {
-                            // We missed some cursor states, because of the limited
-                            // capacity of the channel.
-                            debug!("Ephemeral message channel lagged (this is unfortunate, but okay).");
-                        }
-                    }
-                }
-                Some(message) = self.syncer_receiver.recv() => {
-                    self.receive_peer_message(message).await?;
-                }
-            }
-        }
     }
 }

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -5,10 +5,13 @@
 
 //! This module provides a ConnectionManager, which can be used to connect to other daemons.
 
-use self::sync::{IrohConnection, PeerAuth, SyncActor};
+use self::sync::{Connection, PeerMessage, SyncActor};
 use crate::daemon::DocumentActorHandle;
 use anyhow::{bail, Result};
+use async_trait::async_trait;
+use iroh::endpoint::{RecvStream, SendStream};
 use iroh::{NodeAddr, SecretKey};
+use postcard::{from_bytes, to_allocvec};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
@@ -42,6 +45,11 @@ impl FromStr for SecretAddress {
             passphrase,
         })
     }
+}
+
+enum PeerAuth {
+    MyPassphrase(SecretKey),
+    YourPassphrase(SecretKey),
 }
 
 pub struct ConnectionManager {
@@ -326,5 +334,74 @@ impl EndpointActor {
         // stopped. But in that case, both components will stop, so we can
         // ignore the error.
         let _ = syncer.run().await;
+    }
+}
+
+// Sends/receives PeerMessages to/from and Iroh connection.
+struct IrohConnection {
+    send: SendStream,
+    message_rx: mpsc::Receiver<PeerMessage>,
+}
+
+impl IrohConnection {
+    async fn new(conn: iroh::endpoint::Connection, auth: PeerAuth) -> Result<Self> {
+        let (send, receive) = match auth {
+            PeerAuth::YourPassphrase(passphrase) => {
+                let (mut send, recv) = conn.open_bi().await?;
+
+                send.write_all(&passphrase.to_bytes()).await?;
+
+                (send, recv)
+            }
+            PeerAuth::MyPassphrase(passphrase) => {
+                let (send, mut recv) = conn.accept_bi().await?;
+
+                let mut received_passphrase = [0; 32];
+                recv.read_exact(&mut received_passphrase).await?;
+
+                // Guard against timing attacks.
+                if !constant_time_eq::constant_time_eq(&received_passphrase, &passphrase.to_bytes())
+                {
+                    bail!("Peer provided incorrect passphrase.");
+                }
+
+                (send, recv)
+            }
+        };
+
+        let (message_tx, message_rx) = mpsc::channel(1);
+
+        tokio::spawn(async move {
+            let _ = Self::read(receive, message_tx).await;
+        });
+
+        Ok(Self { send, message_rx })
+    }
+
+    async fn read(mut receive: RecvStream, message_tx: mpsc::Sender<PeerMessage>) -> Result<()> {
+        loop {
+            let mut message_len_buf = [0; 4];
+
+            receive.read_exact(&mut message_len_buf).await?;
+            let byte_count = u32::from_be_bytes(message_len_buf);
+            let mut bytes = vec![0; byte_count as usize];
+            receive.read_exact(&mut bytes).await?;
+            message_tx.send(from_bytes(&bytes)?).await?;
+        }
+    }
+}
+
+#[async_trait]
+impl Connection<PeerMessage> for IrohConnection {
+    async fn send(&mut self, message: PeerMessage) -> Result<()> {
+        let bytes: Vec<u8> = to_allocvec(&message)?;
+        let byte_count = u32::try_from(bytes.len());
+        self.send.write_all(&byte_count?.to_be_bytes()).await?;
+        self.send.write_all(&bytes).await?;
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Option<PeerMessage> {
+        self.message_rx.recv().await
     }
 }

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -46,7 +46,13 @@ impl ConnectionManager {
 
         let secret_address = format!("{}#{}", endpoint.node_id(), my_passphrase);
 
-        let mut actor = EndpointActor::new(endpoint, message_rx, document_handle, my_passphrase);
+        let mut actor = EndpointActor::new(
+            endpoint,
+            message_rx,
+            message_tx.clone(),
+            document_handle,
+            my_passphrase,
+        );
 
         tokio::spawn(async move { actor.run().await });
 
@@ -66,7 +72,7 @@ impl ConnectionManager {
         self.message_tx
             .send(EndpointMessage::Connect {
                 secret_address,
-                response_tx,
+                response_tx: Some(response_tx),
             })
             .await
             .expect("EndpointActor task has been killed");
@@ -141,13 +147,14 @@ enum EndpointMessage {
     // Instruct the endpoint to connect to a new peer.
     Connect {
         secret_address: String,
-        response_tx: oneshot::Sender<Result<()>>,
+        response_tx: Option<oneshot::Sender<Result<()>>>,
     },
 }
 
 struct EndpointActor {
     endpoint: iroh::Endpoint,
     message_rx: mpsc::Receiver<EndpointMessage>,
+    message_tx: mpsc::Sender<EndpointMessage>,
     document_handle: DocumentActorHandle,
     my_passphrase: SecretKey,
 }
@@ -156,12 +163,14 @@ impl EndpointActor {
     fn new(
         endpoint: iroh::Endpoint,
         message_rx: mpsc::Receiver<EndpointMessage>,
+        message_tx: mpsc::Sender<EndpointMessage>,
         document_handle: DocumentActorHandle,
         my_passphrase: SecretKey,
     ) -> Self {
         Self {
             endpoint,
             message_rx,
+            message_tx,
             document_handle,
             my_passphrase,
         }
@@ -178,12 +187,10 @@ impl EndpointActor {
                     panic!("Peer string must have format <node_id>#<passphrase>");
                 }
 
-                dbg!(&secret_address);
                 let public_key = iroh::PublicKey::from_str(parts[0])?;
                 let peer_passphrase = iroh::SecretKey::from_str(parts[1])?;
 
                 let node_addr: iroh::NodeAddr = public_key.into();
-                dbg!(&node_addr);
                 let conn = self.endpoint.connect(node_addr, ALPN).await?;
 
                 info!(
@@ -192,10 +199,13 @@ impl EndpointActor {
                         .expect("Connection should have a node ID")
                 );
 
-                response_tx.send(Ok(())).expect("Connect receiver dropped");
+                if let Some(response_tx) = response_tx {
+                    response_tx.send(Ok(())).expect("Connect receiver dropped");
+                }
 
                 let my_passphrase_clone = self.my_passphrase.clone();
                 let document_handle_clone = self.document_handle.clone();
+                let message_tx_clone = self.message_tx.clone();
                 tokio::spawn(async move {
                     Self::handle_peer(
                         document_handle_clone,
@@ -204,6 +214,16 @@ impl EndpointActor {
                         Some(peer_passphrase),
                     )
                     .await;
+
+                    info!("Connection to peer {public_key} lost, trying to reconnect...");
+                    // We don't need to be notified, so we don't need to use the response channel.
+                    message_tx_clone
+                        .send(EndpointMessage::Connect {
+                            secret_address,
+                            response_tx: None,
+                        })
+                        .await
+                        .expect("Failed to initiate reconnection to peer");
                 });
             }
         }

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -191,7 +191,16 @@ impl EndpointActor {
                 let peer_passphrase = iroh::SecretKey::from_str(parts[1])?;
 
                 let node_addr: iroh::NodeAddr = public_key.into();
-                let conn = self.endpoint.connect(node_addr, ALPN).await?;
+                let conn = match self.endpoint.connect(node_addr, ALPN).await {
+                    Ok(connection) => connection,
+                    Err(_) => {
+                        Self::reconnect(self.message_tx.clone(), secret_address)
+                            .await
+                            .expect("Failed to initiate reconnection");
+                        // Not really Ok, but Ok enough.
+                        return Ok(());
+                    }
+                };
 
                 info!(
                     "Connected to peer: {}",
@@ -214,19 +223,27 @@ impl EndpointActor {
                         Some(peer_passphrase),
                     )
                     .await;
-
-                    info!("Connection to peer {public_key} lost, trying to reconnect...");
-                    // We don't need to be notified, so we don't need to use the response channel.
-                    message_tx_clone
-                        .send(EndpointMessage::Connect {
-                            secret_address,
-                            response_tx: None,
-                        })
+                    Self::reconnect(message_tx_clone, secret_address)
                         .await
-                        .expect("Failed to initiate reconnection to peer");
+                        .expect("Failed to initiate reconnection");
                 });
             }
         }
+        Ok(())
+    }
+
+    async fn reconnect(
+        message_tx: mpsc::Sender<EndpointMessage>,
+        secret_address: String,
+    ) -> Result<()> {
+        info!("Connection to peer TODO lost, trying to reconnect...");
+        // We don't need to be notified, so we don't need to use the response channel.
+        message_tx
+            .send(EndpointMessage::Connect {
+                secret_address,
+                response_tx: None,
+            })
+            .await?;
         Ok(())
     }
 

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -92,6 +92,7 @@ impl ConnectionManager {
             .send(EndpointMessage::Connect {
                 secret_address: SecretAddress::from_str(&secret_address)?,
                 response_tx: Some(response_tx),
+                previous_attempts: 0,
             })
             .await
             .expect("EndpointActor task has been killed");
@@ -170,6 +171,8 @@ enum EndpointMessage {
         // On connection success, this channel will be pinged.
         // Used for the initial connection, where we want to fail if connecting fails.
         response_tx: Option<oneshot::Sender<Result<()>>>,
+        // How many times have we already attempted to connect?
+        previous_attempts: usize,
     },
 }
 
@@ -205,12 +208,13 @@ impl EndpointActor {
             EndpointMessage::Connect {
                 secret_address,
                 response_tx,
+                previous_attempts,
             } => {
                 let node_addr = secret_address.node_addr.clone();
                 let conn = match self.endpoint.connect(node_addr, ALPN).await {
                     Ok(connection) => connection,
                     Err(_) => {
-                        Self::reconnect(self.message_tx.clone(), secret_address)
+                        Self::reconnect(self.message_tx.clone(), secret_address, previous_attempts)
                             .await
                             .expect("Failed to initiate reconnection");
                         // Not really Ok, but Ok enough.
@@ -242,7 +246,7 @@ impl EndpointActor {
                     .await
                     {
                         Ok(()) => {
-                            Self::reconnect(message_tx_clone, secret_address)
+                            Self::reconnect(message_tx_clone, secret_address, 0)
                                 .await
                                 .expect("Failed to initiate reconnection");
                         }
@@ -259,16 +263,26 @@ impl EndpointActor {
     async fn reconnect(
         message_tx: mpsc::Sender<EndpointMessage>,
         secret_address: SecretAddress,
+        previous_attempts: usize,
     ) -> Result<()> {
-        info!(
-            "Connection to peer {} lost, trying to reconnect...",
-            secret_address.node_addr.node_id
-        );
+        // Only log at "info" level if this is the first reconnection attempt.
+        if previous_attempts == 0 {
+            info!(
+                "Connection to peer {} lost, will keep trying to reconnect...",
+                secret_address.node_addr.node_id
+            );
+        } else {
+            debug!(
+                "Making another attempt to connect to peer {}...",
+                secret_address.node_addr.node_id
+            );
+        }
         // We don't need to be notified, so we don't need to use the response channel.
         message_tx
             .send(EndpointMessage::Connect {
                 secret_address,
                 response_tx: None,
+                previous_attempts: previous_attempts + 1,
             })
             .await?;
         Ok(())

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -5,11 +5,11 @@
 
 //! This module provides a ConnectionManager, which can be used to connect to other daemons.
 
-use self::sync::{Connection, PeerMessage, SyncActor};
+use self::sync::{Connection, ConnectionError, PeerMessage, SyncActor};
 use crate::daemon::DocumentActorHandle;
 use anyhow::{bail, Result};
 use async_trait::async_trait;
-use iroh::endpoint::{RecvStream, SendStream};
+use iroh::endpoint::{RecvStream, SendStream, WriteError};
 use iroh::{NodeAddr, SecretKey};
 use postcard::{from_bytes, to_allocvec};
 use std::fs::{self, File, OpenOptions};
@@ -231,8 +231,9 @@ impl EndpointActor {
                 let document_handle_clone = self.document_handle.clone();
                 let message_tx_clone = self.message_tx.clone();
                 tokio::spawn(async move {
-                    // handle_peer currently only returns an error if authentication fails.
-                    // In this case, we don't want to reconnect, but panic!
+                    // If handle_peer returns an Ok, the connection timed out. In that case,
+                    // reconnect.
+                    // In other cases, we got a more serious error, so don't reconnect.
                     match Self::handle_peer(
                         document_handle_clone,
                         conn,
@@ -340,8 +341,7 @@ impl EndpointActor {
     ) -> Result<()> {
         let connection = IrohConnection::new(conn, auth).await?;
         let syncer = SyncActor::new(document_handle, Box::new(connection));
-        let _ = syncer.run().await;
-        Ok(())
+        syncer.run().await
     }
 }
 
@@ -401,11 +401,29 @@ impl IrohConnection {
 
 #[async_trait]
 impl Connection<PeerMessage> for IrohConnection {
-    async fn send(&mut self, message: PeerMessage) -> Result<()> {
-        let bytes: Vec<u8> = to_allocvec(&message)?;
-        let byte_count = u32::try_from(bytes.len());
-        self.send.write_all(&byte_count?.to_be_bytes()).await?;
-        self.send.write_all(&bytes).await?;
+    async fn send(&mut self, message: PeerMessage) -> Result<(), ConnectionError> {
+        let bytes: Vec<u8> = match to_allocvec(&message) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                return Err(ConnectionError::Other);
+            }
+        };
+        let byte_count = u32::try_from(bytes.len()).map_err(|_| ConnectionError::Other)?;
+
+        fn map_timeout(err: WriteError) -> ConnectionError {
+            if let WriteError::ConnectionLost(iroh::endpoint::ConnectionError::TimedOut) = err {
+                ConnectionError::TimedOut
+            } else {
+                ConnectionError::Other
+            }
+        }
+
+        self.send
+            .write_all(&byte_count.to_be_bytes())
+            .await
+            .map_err(map_timeout)?;
+        self.send.write_all(&bytes).await.map_err(map_timeout)?;
+
         Ok(())
     }
 

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -5,7 +5,7 @@
 
 //! This module provides a ConnectionManager, which can be used to connect to other daemons.
 
-use self::sync::SyncActor;
+use self::sync::{IrohConnection, PeerAuth, SyncActor};
 use crate::daemon::DocumentActorHandle;
 use anyhow::{bail, Result};
 use iroh::{NodeAddr, SecretKey};
@@ -223,15 +223,13 @@ impl EndpointActor {
                     response_tx.send(Ok(())).expect("Connect receiver dropped");
                 }
 
-                let my_passphrase_clone = self.my_passphrase.clone();
                 let document_handle_clone = self.document_handle.clone();
                 let message_tx_clone = self.message_tx.clone();
                 tokio::spawn(async move {
                     Self::handle_peer(
                         document_handle_clone,
                         conn,
-                        my_passphrase_clone,
-                        Some(secret_address.passphrase.clone()),
+                        PeerAuth::YourPassphrase(secret_address.passphrase.clone()),
                     )
                     .await;
                     Self::reconnect(message_tx_clone, secret_address)
@@ -278,8 +276,7 @@ impl EndpointActor {
                                         Self::handle_peer(
                                             document_handle_clone,
                                             conn,
-                                            my_passphrase_clone,
-                                            None,
+                                            PeerAuth::MyPassphrase(my_passphrase_clone),
                                         )
                                         .await;
 
@@ -315,36 +312,19 @@ impl EndpointActor {
     async fn handle_peer(
         document_handle: DocumentActorHandle,
         conn: iroh::endpoint::Connection,
-        my_passphrase: SecretKey,
-        peer_passphrase: Option<SecretKey>,
+        auth: PeerAuth,
     ) {
-        let (to_peer_tx, to_peer_rx) = mpsc::channel(16);
-        let (from_peer_tx, from_peer_rx) = mpsc::channel(16);
+        let connection = IrohConnection::new(conn, auth)
+            .await
+            .expect("Failed to authenticate connection");
+        dbg!("authed");
+        let syncer = SyncActor::new(document_handle, Box::new(connection));
 
-        let syncer = SyncActor::new(document_handle, from_peer_rx, to_peer_tx);
-
-        let syncer_handle = tokio::spawn(async move {
-            // The syncer can fail when the protocol_handler below has
-            // stopped. But in that case, both components will stop, so we can
-            // ignore the error.
-            if let Err(e) = syncer.run().await {
-                error!("Syncing failed with: {e}");
-            }
-        });
-
-        // This is a function that either runs forever, or errors.
-        // But errors just mean that the connection was closed/interrupted, so we ignore them.
-        let _ = sync::protocol_handler(
-            conn,
-            from_peer_tx,
-            to_peer_rx,
-            my_passphrase,
-            peer_passphrase,
-        )
-        .await;
-
-        // TODO: Do we still this abort? The syncer should stop anyway once it cannot use its
-        // to_peer_tx anymore.
-        syncer_handle.abort_handle().abort();
+        // The syncer can fail when the protocol_handler below has
+        // stopped. But in that case, both components will stop, so we can
+        // ignore the error.
+        if let Err(e) = syncer.run().await {
+            error!("Syncing failed with: {e}");
+        }
     }
 }

--- a/daemon/src/peer/sync.rs
+++ b/daemon/src/peer/sync.rs
@@ -1,0 +1,204 @@
+use crate::daemon::{DocMessage, DocumentActorHandle};
+use crate::types::EphemeralMessage;
+use anyhow::{Context, Result};
+use automerge::sync::{Message as AutomergeSyncMessage, State as SyncState};
+use iroh::SecretKey;
+use postcard::{from_bytes, to_allocvec};
+use serde::{Deserialize, Serialize};
+use std::mem;
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tracing::{debug, error, warn};
+
+#[derive(Deserialize, Serialize)]
+/// The PeerMessage is used for peer to peer data exchange.
+pub enum PeerMessage {
+    /// The Sync message contains the changes to the CRDT
+    Sync(Vec<u8>),
+    /// The Ephemeral message currently is used for cursor messages, but can later be used for
+    /// other things that should not be persisted.
+    Ephemeral(EphemeralMessage),
+}
+
+/// Core low-level syncing protocol.
+pub async fn protocol_handler(
+    conn: iroh::endpoint::Connection,
+    from_peer_tx: mpsc::Sender<PeerMessage>,
+    mut to_peer_rx: mpsc::Receiver<PeerMessage>,
+    my_passphrase: SecretKey,
+    peer_passphrase: Option<SecretKey>,
+) -> Result<()> {
+    let (mut send, mut recv) = if let Some(peer_passphrase) = peer_passphrase {
+        let (mut send, recv) = conn.open_bi().await?;
+
+        send.write_all(&peer_passphrase.to_bytes()).await?;
+
+        (send, recv)
+    } else {
+        let (send, mut recv) = conn.accept_bi().await?;
+
+        let mut received_passphrase = [0; 32];
+        recv.read_exact(&mut received_passphrase).await?;
+
+        // Guard against timing attacks.
+        if !constant_time_eq::constant_time_eq(&received_passphrase, &my_passphrase.to_bytes()) {
+            warn!("Peer provided incorrect passphrase.");
+            return Ok(());
+        }
+
+        (send, recv)
+    };
+
+    loop {
+        let mut message_len_buf = [0; 4];
+
+        tokio::select! {
+            message_maybe = to_peer_rx.recv() => {
+                match message_maybe {
+                    Some(message) => {
+                        let bytes: Vec<u8> = to_allocvec(&message)?;
+                        let byte_count = u32::try_from(bytes.len());
+                        send
+                            .write_all(&byte_count?.to_be_bytes())
+                            .await?;
+                        send
+                            .write_all(&bytes)
+                            .await?;
+                        }
+                    None => {
+                        // TODO: What should we do?
+                        error!("None on to_peer_rx");
+                    }
+                }
+            }
+            _ = recv.read_exact(&mut message_len_buf) => {
+                let byte_count = u32::from_be_bytes(message_len_buf);
+                let mut bytes = vec![0; byte_count as usize];
+                recv.read_exact(&mut bytes).await?;
+
+                let message = from_bytes(&bytes)?;
+
+                from_peer_tx.send(message).await?;
+            }
+        }
+    }
+}
+
+/// Transport-agnostic logic of how to sync with another peer.
+/// Receives Automerge sync messages on one channel, and sends some out on another.
+/// Maintains the sync state, and communicates with the document.
+pub struct SyncActor {
+    peer_state: SyncState,
+    document_handle: DocumentActorHandle,
+    syncer_receiver: mpsc::Receiver<PeerMessage>,
+    syncer_sender: mpsc::Sender<PeerMessage>,
+}
+
+impl SyncActor {
+    pub fn new(
+        document_handle: DocumentActorHandle,
+        syncer_receiver: mpsc::Receiver<PeerMessage>,
+        syncer_sender: mpsc::Sender<PeerMessage>,
+    ) -> Self {
+        Self {
+            peer_state: SyncState::new(),
+            document_handle,
+            syncer_receiver,
+            syncer_sender,
+        }
+    }
+
+    async fn receive_peer_message(&mut self, message: PeerMessage) -> Result<()> {
+        let (reponse_tx, response_rx) = oneshot::channel();
+        match message {
+            PeerMessage::Sync(message_buf) => {
+                let message = AutomergeSyncMessage::decode(&message_buf)?;
+                self.document_handle
+                    .send_message(DocMessage::ReceiveSyncMessage {
+                        message,
+                        state: mem::take(&mut self.peer_state),
+                        response_tx: reponse_tx,
+                    })
+                    .await;
+                self.peer_state = response_rx
+                    .await
+                    .expect("Couldn't read response from Document channel");
+            }
+            PeerMessage::Ephemeral(cursor) => {
+                self.document_handle
+                    .send_message(DocMessage::ReceiveEphemeral(cursor))
+                    .await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn generate_sync_message(&mut self) -> Result<()> {
+        let (reponse_tx, response_rx) = oneshot::channel();
+        self.document_handle
+            .send_message(DocMessage::GenerateSyncMessage {
+                state: mem::take(&mut self.peer_state),
+                response_tx: reponse_tx,
+            })
+            .await;
+        let (ps, message) = response_rx
+            .await
+            .context("Could not read response from Document channel")?;
+        self.peer_state = ps;
+        if let Some(message) = message {
+            self.syncer_sender
+                .send(PeerMessage::Sync(message.encode()))
+                .await
+                .context("Failed to send sync message on syncer_sender channel")?;
+        }
+        Ok(())
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        let mut doc_changed_ping_rx = self.document_handle.subscribe_document_changes();
+        let mut ephemeral_messages_rx = self.document_handle.subscribe_ephemeral_messages();
+
+        // Kick off initial synchronization with peer.
+        self.generate_sync_message().await?;
+
+        loop {
+            tokio::select! {
+                // As doc_changed_ping_rx is a broadcast channel our understanding is,
+                // that this breaks a potential cyclic deadlock between SyncerActor
+                // and TCPActor (e.g. when TCPWriteActor.send blocks).
+                doc_ping = doc_changed_ping_rx.recv() => {
+                    match doc_ping {
+                        Ok(()) => { self.generate_sync_message().await?; }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            panic!("Doc changed channel has been closed");
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                            // This is fine, the messages in this channel are just pings.
+                            // It's fine if we miss some.
+                            debug!("Doc changed ping channel lagged (this is probably fine).");
+                        }
+                    }
+                }
+                ephemeral_message = ephemeral_messages_rx.recv() => {
+                    match ephemeral_message {
+                        Ok(ephemeral_message) => {
+                            self.syncer_sender.send(PeerMessage::Ephemeral(ephemeral_message))
+                                .await
+                                .context("Failed to send ephemeral message on syncer_sender channel")?;
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            panic!("Ephemeral message channel has been closed");
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                            // We missed some cursor states, because of the limited
+                            // capacity of the channel.
+                            debug!("Ephemeral message channel lagged (this is unfortunate, but okay).");
+                        }
+                    }
+                }
+                Some(message) = self.syncer_receiver.recv() => {
+                    self.receive_peer_message(message).await?;
+                }
+            }
+        }
+    }
+}

--- a/daemon/src/peer/sync.rs
+++ b/daemon/src/peer/sync.rs
@@ -84,8 +84,8 @@ pub async fn protocol_handler(
 }
 
 /// Transport-agnostic logic of how to sync with another peer.
-/// Receives Automerge sync messages on one channel, and sends some out on another.
-/// Maintains the sync state, and communicates with the document.
+/// Exchanges PeerMessages with the "syncer", and communicates with the document on the other side.
+/// Maintains the sync state.
 pub struct SyncActor {
     peer_state: SyncState,
     document_handle: DocumentActorHandle,

--- a/daemon/src/peer/sync.rs
+++ b/daemon/src/peer/sync.rs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
+// SPDX-FileCopyrightText: 2025 zormit <nt4u@kpvn.de>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use crate::daemon::{DocMessage, DocumentActorHandle};
 use crate::types::EphemeralMessage;
 use anyhow::{bail, Context, Result};

--- a/daemon/src/watcher.rs
+++ b/daemon/src/watcher.rs
@@ -124,6 +124,9 @@ impl Watcher {
                         }
                     }
                 }
+                EventKind::Access(_) => {
+                    // We're not interested in these, ignore them.
+                }
                 e => {
                     // Don't handle other events.
                     // But log them! I'm curious what they are!


### PR DESCRIPTION
These reconnections seem useful if you basically want to "stay connected" to your peer forever.

This PR restructures the peer code around a "ConnectionManager", which spawns an "EndpointActor", which can receive requests to make connections. When the EndpointActor decides that a reconnect makes sense, it will send such a message to itself.

It's the first time I needed to do some more "proper" error handling, because we want to be able to tell whether the reason for a failure was a timeout, or something else a couple of layers higher up. It's not really pretty.

## Ideas for how to make stuff prettier

(But maybe that's for a later PR?)

The main other failure reason I see is an authorization failure. The joining peer will not get any feedback on that failure, unfortunately – its next communication attempt will just fail. We could modify the peer protocol a bit so that we can tell earlier when an auth failure happens, and then do two steps:

1. Try auth, if it fails, always stop
2. Start regular connection, if it fails, always reconnect?