### PR TITLE
Use .ethersync/socket as daemon socket

### DIFF
--- a/book/src/editor-plugin-dev-guide.md
+++ b/book/src/editor-plugin-dev-guide.md
@@ -107,15 +107,15 @@ These should be sent as notifications, there is no need to reply to them.
 
 To send messages to the daemon manually, you can try the following. Assuming you can start the daemon on a playground as described in the [first steps](first-steps.md), now we add some debugging output:
 ```bash
-RUST_LOG=debug ethersync share playground
-# Note for below: You will see some output like "Listening on UNIX socket: /tmp/ethersync"
+RUST_LOG=ethersync=debug ethersync share playground
+# Note for below: You will see some output like "Listening on UNIX socket: <dir>/.ethersync/socket"
 ```
-You can then start the client, in another terminal:
+You can then start the client, in another terminal, but in the same directory:
 ```bash
 ethersync client
 ```
 This will already produce an output in the daemon which indicates that an Editor connected.
-This happens because the client connects to the `/tmp/ethersync` socket.
+This happens because the client connects to the daemon's socket.
 Killing it shows the opposite: "Editor disconnected".
 
 Next, you could manually send some JSON-RPC. We included a Python script to help you create messages in the correct format: Run it to see what an open message could look like:
@@ -136,7 +136,7 @@ On the other hand, not running any daemon, you can see what the plugin "wants" t
 In the demon console (stop it), we now just plainly listen on the socket for incoming data:
 ```bash
 # nc can only bind to existing sockets, so we'll drop potentially existing ones
-rm /tmp/ethersync; nc -lk -U /tmp/ethersync
+rm <dir>/.ethersync/socket; nc -lk -U <dir>/.ethersync/socket
 ```
 
 In the client console, start nvim on a file, move the cursor and edit something:
@@ -155,9 +155,8 @@ Do do that on a single machine, follow these steps:
 3. Start the second daemon:
     - The directory should be the additional directory you created.
     - Use `ethersync join <join code>`.
-    - Set `--socket-name` to a new value like `ethertwo`.
 4. Connect an editor to the first daemon by opening a file in the first directory.
-5. Connect an editor to the second daemon by setting the environment variable `ETHERSYNC_SOCKET` to the new value before opening a file in the second directory.
-    - Example: `ETHERSYNC_SOCKET=ethertwo nvim directory2/file`
+5. Connect an editor to the second daemon.
+    - Example: `nvim directory2/file`
 
 Things you type into the first editor should now appear in the second editor, and vice versa.

--- a/book/src/editor-plugin-dev-guide.md
+++ b/book/src/editor-plugin-dev-guide.md
@@ -151,7 +151,7 @@ For testing purposes, it can be useful to simulate having two peers connecting t
 Do do that on a single machine, follow these steps:
 
 1. Start one daemon regularly, we will call its directory the "first directory".
-2. Create a new, empty shared directory (with an `.ethersync` directory in it) for the second daemon.
+2. Create a new, empty directory for the second daemon.
 3. Start the second daemon:
     - The directory should be the additional directory you created.
     - Use `ethersync join <join code>`.

--- a/book/src/first-steps.md
+++ b/book/src/first-steps.md
@@ -9,28 +9,16 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Here's how to try out Ethersync!
 
-## 🎬 1. Set up a project to share
+## 🎬 1. Share a directory
 
-Our current convention is to have a subdirectory called `.ethersync` in an Ethersync-enabled directory. So create them both:
-
-```bash
-mkdir -p playground/.ethersync
-cd playground
-touch file
-```
-
-Then, start the Ethersync daemon in the project directory:
+In an empty directory, run:
 
 ```bash
 ethersync share
 ```
 This will print a "join code" that others can use to connect.
 
-## 🖥 2. Try Ethersync on your own computer
-
-First, let's see changes across two different text editors!
-
-Open the file in a new terminal:
+Open a file in the project directory:
 
 ```bash
 nvim file
@@ -38,43 +26,25 @@ nvim file
 
 You should see `Ethersync activated!` in Neovim, and a `Client connected` message in the logs of the daemon.
 
-> 💡 **Tip**
->
-> If that doesn't work, make sure that the `ethersync` command is in the `PATH` in the terminal where you run Neovim.
 
-Next, in order to see Ethersync working, you can open the file again in a *third* terminal:
+## 🧑‍🤝‍🧑 2. Join the directory
 
-```bash
-nvim file
-```
-The edits you make in one editor should now appear in both!
+You can try this on your local computer with a different directory, but it also works over the network!
 
-Note that using two editors is not the main use-case of Ethersync. We show it here for demonstrating purposes.
-
-
-## 🧑‍🤝‍🧑 3. Collaborate with other people
-
-If a friend now wants to join the collaboration from another computer, they need to follow these steps:
-
-### Prepare the project directory
-
-```bash
-mkdir -p playground/.ethersync
-cd playground
-```
-
-### Start the daemon
-
-To connect, run a command like this, with the "join code" output by the daemon on the first computer:
+In another empty directory run the join command that the first daemon printed:
 
 ```bash
 ethersync join 3-exhausted-bananas
 ```
 
-Both sides will indicate success with a log message "Peer connected" and "Connected to peer" respectively. If you don't see it, double-check the previous steps.
+Both sides will indicate success with a log message "Peer connected" and "Connected to peer" respectively.
 
-### Start collaborating in real-time!
-
-If everything worked, connected peers can now collaborate on existing files by opening them in their editors.
-Type somethings and the changes will be transferred over!
+Connected peers can now collaborate on existing files by opening them in their editors.
+Type something and the changes will be transferred over!
 You should also see your peer's cursor.
+
+## Troubleshooting
+
+### Opening files in Neovim doesn't show a "Client connected" message in the logs of the daemon.
+
+Make sure that the `ethersync` command is in the `PATH` in the terminal where you run Neovim.

--- a/book/src/git-integration.md
+++ b/book/src/git-integration.md
@@ -35,24 +35,25 @@ However, any change to the `.git` directory and the staging area (which is in fa
 
 This means that most Git operations you might try will not have an effect on connected peers.
 
-### Git commands that are safe to run
+### Git commands that don't modify files
 
-These commands will not lead to inconsistent behaviour (however, changes in your index or in your commits will not be shared with peers):
+These commands will not modify files, so you can run them without affecting connected peers (note that changes in your index or in your commits will not be shared):
 
 - Checking what you have been doing so far with `git diff` / `git status`.
 - Use `git add` and the like to stage changes.
 - Use `git commit` to, well, create a commit in the current branch.
 
-### Git commands that are *not* safe to run
+### Git commands that modify files
 
-Because these commands might change file contents (without going through an editor), they might lead to different file contents, compared to your peers:
+These commands might change file contents (without going through an editor). The file watcher should pick them up, but currently, they might trigger a deletion and re-creation of the affected files.
+This is problematic if it happens in parallel to changes from other peers, or if they have them open in editors. We hope to build a smoother experience someday.
 
 - Synchronizing with a remote repository with `git push` and `git fetch`.
 - Use `git switch`/`git checkout` to switch to a different branch or get a specific file state from history.
 - Use `git reset --soft` or `git reset --mixed` to modify the staging area and the HEAD "manually".
 - Use `git restore`/`git checkout -- <pathspec>`/`git reset --hard HEAD` to undo your changes or get a different content of a file from the Git history.
 
-If you need to run these commands while pairing, temporarily turn off Ethersync, make the change, and then reconnect. The daemon will then pick up changes, as described in the section about [offline support](offline-support.md).
+If you notice any discrepancies between directory content of connected peers, you can turn off the daemon, and restart it. The daemon will then pick up changes, as described in the section about [offline support](offline-support.md).
 
 ## Recommended pair-programming workflow
 

--- a/book/src/pair-programming.md
+++ b/book/src/pair-programming.md
@@ -23,16 +23,7 @@ Make sure you're both inside the project directory on the command line.
 
 Also this guide assumes you're in the same local network. For other connections consider reading the section on [connection making](connection-making.md).
 
-### 2. Create the `.ethersync` directory
-
-This is our convention to mark a project as shareable: It needs to have a directory called `.ethersync` in it. So both peers should make sure that it exists:
-
-```bash
-mkdir .ethersync
-```
-Note that this directory, similar to a `.git` directory will *not* be synchronized.
-
-### 3. First peer
+### 2. First peer
 
 To start the session, run:
 
@@ -40,12 +31,11 @@ To start the session, run:
 ethersync share
 ```
 
-This will print, among other initialization information, a [join code](connection-making.md#join code)
-) which looks like `3-exhausted-bananas`.
+This will print, among other initialization information, a [join code](connection-making.md#join-codes), which looks like `3-exhausted-bananas`.
 
 You can share this with one other person, to allow them to connect.
 
-### 4. Other peers
+### 3. Other peers
 
 To join a session, run a command like this:
 
@@ -55,14 +45,14 @@ ethersync join 3-exhausted-bananas
 
 This should show you a message like "Connected to peer: ...". The hosting daemon should show a message like "Peer connected: ...".
 
-### 5. Collaborate!
+### 4. Collaborate!
 
 Connected peers can now open files and edit them together. Note the [common pitfalls](workarounds.md).
 
-### 6. Stop Ethersync
+### 5. Stop Ethersync
 
 To stop collaborating, stop the daemon (by pressing Ctrl-C in its terminal). Both peers will still have the code they worked on, and can continue their work independently.
 
-### 7. Reconnect later
+### 6. Reconnect later
 
 If you later want to do another pairing session, make sure that you understand Ethersync's [offline support](offline-support.md) feature and the [local first](local-first.md) concept. When you re-start Ethersync, it will scan for changes you've made in the meantime, and try to send them to the other peer. It is probably safest if you delete the CRDT state in `.ethersync/doc` as a joining peer. The hosting peer doesn't need to do that, it will simply update their state to the latest file content and share that with others.

--- a/book/src/shared-notes.md
+++ b/book/src/shared-notes.md
@@ -19,10 +19,10 @@ You need to have access to a server on the Internet, and install the Ethersync d
 
 ### 1. Set up the directory
 
-On the server, create a new directory for your shared project, as well as an `.ethersync` directory inside it:
+On the server, create a new directory for your shared project:
 
 ```bash
-mkdir my-project/.ethersync
+mkdir my-project
 cd my-project
 ```
 

--- a/book/src/workarounds.md
+++ b/book/src/workarounds.md
@@ -9,24 +9,6 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Some things about Ethersync are currently still a bit annoying. Let us show you how to work around them!
 
-## Sharing multiple projects requires configuring the socket
-
-Ethersync currently only supports sharing a single project directory per daemon. If you want to sync more than one project, you can do so by starting a second daemon. The trick is to use a different socket for the editors to connect to.
-
-1. When starting the second daemon, use the `--socket-name` option, like this:
-
-    ```bash
-    ethersync join --socket-name ethersync2
-    ```
-
-2. Before opening a file in the second project directory, set the `ETHERSYNC_SOCKET` environment variable to the correct path, like this:
-
-    ```bash
-    export ETHERSYNC_SOCKET=ethersync2
-    ```
-
-It can be convenient to set this environment variable using [direnv](https://direnv.net). The `ethersync` commands will all observe it.
-
 ## Restarting the daemon requires restarting the editor
 
 The editor plugins currently only try to connect to Ethersync when they first start. If you need to restart the daemon for any reason, you will also need to restart all open editors to reconnect.

--- a/book/src/workarounds.md
+++ b/book/src/workarounds.md
@@ -12,12 +12,3 @@ Some things about Ethersync are currently still a bit annoying. Let us show you 
 ## Restarting the daemon requires restarting the editor
 
 The editor plugins currently only try to connect to Ethersync when they first start. If you need to restart the daemon for any reason, you will also need to restart all open editors to reconnect.
-
-## Editing a file with tools that don't have Ethersync support
-
-We are [planning](https://github.com/ethersync/ethersync/pull/133) to support this in a smoother way, but currently it's recommended to:
-- turn off the daemon
-- make your edits
-- start the daemon again.
-
-It will then compare the ["last seen"](local-first.md) state with what you have on disk and synchronize your edits to other peers.

--- a/daemon/integration-tests/Cargo.toml
+++ b/daemon/integration-tests/Cargo.toml
@@ -22,6 +22,7 @@ nvim-rs = { version = "0.7.0", features = ["use_tokio"] }
 rand = "0.8.5"
 temp-dir = "0.1.13"
 tokio = { version = "1", default-features = false, features = ["process"] }
+serde_json = "1"
 
 [dependencies.ethersync]
 path = ".."
@@ -30,7 +31,6 @@ default-features = false
 [dev-dependencies]
 futures = { version = "0.3.30", default-features = false }
 pretty_assertions = "1.4.0"
-serde_json = "1"
 serial_test = "3.1.1"
 tracing = "0.1.40"
 anyhow = "1.0.81"

--- a/daemon/integration-tests/src/actors.rs
+++ b/daemon/integration-tests/src/actors.rs
@@ -159,15 +159,18 @@ fn rand_usize_inclusive(start: usize, end: usize) -> usize {
 }
 
 impl Neovim {
-    pub async fn new_ethersync_enabled(initial_content: &str) -> (Self, PathBuf) {
+    pub async fn new_ethersync_enabled(initial_content: &str) -> (Self, PathBuf, PathBuf) {
         let dir = TempDir::new().unwrap();
         let ethersync_dir = dir.child(".ethersync");
         sandbox::create_dir(dir.path(), &ethersync_dir).unwrap();
+
         let mut file_path = dir.child("test");
         sandbox::write_file(dir.path(), &file_path, initial_content.as_bytes())
             .expect("Failed to write initial file content");
         file_path = fs::canonicalize(file_path).expect("Could not canonicalize");
 
-        (Self::new(file_path.clone()).await, file_path)
+        let socket_path = dir.child("socket");
+
+        (Self::new(file_path.clone()).await, file_path, socket_path)
     }
 }

--- a/daemon/integration-tests/src/lib.rs
+++ b/daemon/integration-tests/src/lib.rs
@@ -4,3 +4,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 pub mod actors;
+pub mod socket;

--- a/daemon/integration-tests/src/socket.rs
+++ b/daemon/integration-tests/src/socket.rs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
+// SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use ethersync::sandbox;
+use serde_json::Value as JSONValue;
+use std::path::Path;
+use tokio::{
+    io::{split, AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
+    net::UnixListener,
+    sync::mpsc,
+    time::Duration,
+};
+
+pub struct MockSocket {
+    writer_tx: tokio::sync::mpsc::Sender<String>,
+    reader_rx: tokio::sync::mpsc::Receiver<String>,
+}
+
+impl MockSocket {
+    pub fn new(socket_path: &Path) -> Self {
+        let socket_dir = socket_path
+            .parent()
+            .expect("The constructed socket paths should be in a directory");
+        if sandbox::exists(socket_dir, &socket_path).expect("Could not check for socket existence")
+        {
+            sandbox::remove_file(socket_dir, &socket_path).expect("Could not remove socket");
+        }
+
+        let listener = UnixListener::bind(socket_path).expect("Could not bind to socket");
+        let (writer_tx, mut writer_rx) = mpsc::channel::<String>(1);
+        let (reader_tx, reader_rx) = mpsc::channel::<String>(1);
+
+        tokio::spawn(async move {
+            let (socket, _) = listener
+                .accept()
+                .await
+                .expect("Could not accept connection");
+
+            let (reader, writer) = split(socket);
+            let mut writer = BufWriter::new(writer);
+            let mut reader = BufReader::new(reader);
+
+            tokio::spawn(async move {
+                while let Some(message) = writer_rx.recv().await {
+                    writer
+                        .write_all(message.as_bytes())
+                        .await
+                        .expect("Could not write to socket");
+                    writer.flush().await.expect("Could not flush socket");
+                }
+            });
+
+            tokio::spawn(async move {
+                let mut buffer = String::new();
+                while reader.read_line(&mut buffer).await.is_ok() {
+                    reader_tx
+                        .send(buffer.clone())
+                        .await
+                        .expect("Could not send message to reader channel");
+                    buffer.clear();
+                }
+            });
+        });
+
+        Self {
+            writer_tx,
+            reader_rx,
+        }
+    }
+
+    pub async fn send(&mut self, message: &str) {
+        self.writer_tx
+            .send(message.to_string())
+            .await
+            .expect("Could not send message");
+    }
+
+    pub async fn recv(&mut self) -> JSONValue {
+        let line = self
+            .reader_rx
+            .recv()
+            .await
+            .expect("Could not receive message");
+        serde_json::from_str(&line).expect("Could not parse JSON")
+    }
+
+    pub async fn acknowledge_open(&mut self) -> JSONValue {
+        let json = self.recv().await;
+        if json.get("method").unwrap() == "open" {
+            let id = json.get("id").unwrap();
+            let response = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": "success"
+            });
+            self.send(&response.to_string()).await;
+            self.send("\n").await;
+            // Wait a bit so that Neovim can boot up its change tracking.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        json
+    }
+}

--- a/daemon/integration-tests/src/socket.rs
+++ b/daemon/integration-tests/src/socket.rs
@@ -23,9 +23,8 @@ impl MockSocket {
         let socket_dir = socket_path
             .parent()
             .expect("The constructed socket paths should be in a directory");
-        if sandbox::exists(socket_dir, &socket_path).expect("Could not check for socket existence")
-        {
-            sandbox::remove_file(socket_dir, &socket_path).expect("Could not remove socket");
+        if sandbox::exists(socket_dir, socket_path).expect("Could not check for socket existence") {
+            sandbox::remove_file(socket_dir, socket_path).expect("Could not remove socket");
         }
 
         let listener = UnixListener::bind(socket_path).expect("Could not bind to socket");

--- a/daemon/integration-tests/tests/vim-plugin.rs
+++ b/daemon/integration-tests/tests/vim-plugin.rs
@@ -5,7 +5,6 @@
 
 use ethersync_integration_tests::actors::*;
 
-use ethersync::editor::get_socket_path;
 use ethersync::sandbox;
 use ethersync::types::{
     factories::*, EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor,
@@ -30,8 +29,7 @@ struct MockSocket {
 }
 
 impl MockSocket {
-    fn new(socket_name: &Path) -> Self {
-        let socket_path = get_socket_path(socket_name);
+    fn new(socket_path: &Path) -> Self {
         let socket_dir = socket_path
             .parent()
             .expect("The constructed socket paths should be in a directory");
@@ -147,10 +145,8 @@ async fn assert_vim_deltas_yield_content(
     deltas: Vec<EditorTextOp>,
     expected_content: &str,
 ) {
-    let socket_name = "ethersync-vim-integration-test-deltas";
-    let mut socket = MockSocket::new(Path::new(socket_name));
-    std::env::set_var("ETHERSYNC_SOCKET", socket_name);
-    let (nvim, file_path) = Neovim::new_ethersync_enabled(initial_content).await;
+    let (nvim, file_path, socket_path) = Neovim::new_ethersync_enabled(initial_content).await;
+    let mut socket = MockSocket::new(&Path::new(&socket_path));
     socket.acknowledge_open().await;
 
     for op in &deltas {
@@ -227,10 +223,8 @@ async fn assert_vim_input_yields_replacements(
     mut expected_replacements: Vec<EditorTextOp>,
 ) {
     timeout(Duration::from_millis(5000), async {
-                let socket_name = "ethersync-vim-integration-test-replacements";
-                let mut socket = MockSocket::new(Path::new(socket_name));
-                std::env::set_var("ETHERSYNC_SOCKET", socket_name);
-                let (mut nvim, _file_path) = Neovim::new_ethersync_enabled(initial_content).await;
+                let (mut nvim, _file_path, socket_path) = Neovim::new_ethersync_enabled(initial_content).await;
+                let mut socket = MockSocket::new(&Path::new(&socket_path));
                 socket.acknowledge_open().await;
 
                 {

--- a/daemon/integration-tests/tests/vim-plugin.rs
+++ b/daemon/integration-tests/tests/vim-plugin.rs
@@ -4,115 +4,16 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use ethersync_integration_tests::actors::*;
+use ethersync_integration_tests::socket::*;
 
-use ethersync::sandbox;
 use ethersync::types::{
     factories::*, EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor,
     EditorProtocolObject, EditorTextDelta, EditorTextOp, JSONRPCFromEditor,
 };
 
 use pretty_assertions::assert_eq;
-use serde_json::Value as JSONValue;
 use serial_test::serial;
 use tokio::time::{timeout, Duration};
-use tokio::{
-    io::{split, AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
-    net::UnixListener,
-    sync::mpsc,
-};
-
-use std::path::Path;
-
-struct MockSocket {
-    writer_tx: tokio::sync::mpsc::Sender<String>,
-    reader_rx: tokio::sync::mpsc::Receiver<String>,
-}
-
-impl MockSocket {
-    fn new(socket_path: &Path) -> Self {
-        let socket_dir = socket_path
-            .parent()
-            .expect("The constructed socket paths should be in a directory");
-        if sandbox::exists(socket_dir, &socket_path).expect("Could not check for socket existence")
-        {
-            sandbox::remove_file(socket_dir, &socket_path).expect("Could not remove socket");
-        }
-
-        let listener = UnixListener::bind(socket_path).expect("Could not bind to socket");
-        let (writer_tx, mut writer_rx) = mpsc::channel::<String>(1);
-        let (reader_tx, reader_rx) = mpsc::channel::<String>(1);
-
-        tokio::spawn(async move {
-            let (socket, _) = listener
-                .accept()
-                .await
-                .expect("Could not accept connection");
-
-            let (reader, writer) = split(socket);
-            let mut writer = BufWriter::new(writer);
-            let mut reader = BufReader::new(reader);
-
-            tokio::spawn(async move {
-                while let Some(message) = writer_rx.recv().await {
-                    writer
-                        .write_all(message.as_bytes())
-                        .await
-                        .expect("Could not write to socket");
-                    writer.flush().await.expect("Could not flush socket");
-                }
-            });
-
-            tokio::spawn(async move {
-                let mut buffer = String::new();
-                while reader.read_line(&mut buffer).await.is_ok() {
-                    reader_tx
-                        .send(buffer.clone())
-                        .await
-                        .expect("Could not send message to reader channel");
-                    buffer.clear();
-                }
-            });
-        });
-
-        Self {
-            writer_tx,
-            reader_rx,
-        }
-    }
-
-    async fn send(&mut self, message: &str) {
-        self.writer_tx
-            .send(message.to_string())
-            .await
-            .expect("Could not send message");
-    }
-
-    async fn recv(&mut self) -> JSONValue {
-        let line = self
-            .reader_rx
-            .recv()
-            .await
-            .expect("Could not receive message");
-        serde_json::from_str(&line).expect("Could not parse JSON")
-    }
-
-    async fn acknowledge_open(&mut self) -> JSONValue {
-        let json = self.recv().await;
-        if json.get("method").unwrap() == "open" {
-            let id = json.get("id").unwrap();
-            let response = serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": "success"
-            });
-            self.send(&response.to_string()).await;
-            self.send("\n").await;
-            // Wait a bit so that Neovim can boot up its change tracking.
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        json
-    }
-}
 
 #[tokio::test]
 async fn plugin_loaded() {

--- a/daemon/integration-tests/tests/vim-plugin.rs
+++ b/daemon/integration-tests/tests/vim-plugin.rs
@@ -42,7 +42,7 @@ async fn ethersync_executable_from_vim() {
 
 #[tokio::test]
 async fn vim_sends_something_to_socket() {
-    let (nvim, file_path, mut socket, _dir) = Neovim::new_ethersync_enabled("hi").await;
+    let (nvim, _file_path, mut socket, _dir) = Neovim::new_ethersync_enabled("hi").await;
     dbg!(nvim.content().await);
     timeout(Duration::from_millis(1000), async {
         socket.acknowledge_open().await;

--- a/daemon/integration-tests/tests/vim-plugin.rs
+++ b/daemon/integration-tests/tests/vim-plugin.rs
@@ -145,8 +145,9 @@ async fn assert_vim_deltas_yield_content(
     deltas: Vec<EditorTextOp>,
     expected_content: &str,
 ) {
-    let (nvim, file_path, socket_path) = Neovim::new_ethersync_enabled(initial_content).await;
-    let mut socket = MockSocket::new(&Path::new(&socket_path));
+    let (nvim, file_path, socket_path, _temp_dir) =
+        Neovim::new_ethersync_enabled(initial_content).await;
+    let mut socket = MockSocket::new(&socket_path);
     socket.acknowledge_open().await;
 
     for op in &deltas {
@@ -223,8 +224,8 @@ async fn assert_vim_input_yields_replacements(
     mut expected_replacements: Vec<EditorTextOp>,
 ) {
     timeout(Duration::from_millis(5000), async {
-                let (mut nvim, _file_path, socket_path) = Neovim::new_ethersync_enabled(initial_content).await;
-                let mut socket = MockSocket::new(&Path::new(&socket_path));
+                let (mut nvim, _file_path, socket_path, _temp_dir) = Neovim::new_ethersync_enabled(initial_content).await;
+                let mut socket = MockSocket::new(&socket_path);
                 socket.acknowledge_open().await;
 
                 {

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -11,6 +11,10 @@ use ini::Ini;
 use std::path::Path;
 use tracing::info;
 
+pub const DEFAULT_SOCKET_NAME: &str = "socket";
+pub const CONFIG_DIR: &str = ".ethersync";
+pub const CONFIG_FILE: &str = "config";
+
 const EMIT_JOIN_CODE_DEFAULT: bool = true;
 const EMIT_SECRET_ADDRESS_DEFAULT: bool = false;
 

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -762,6 +762,10 @@ impl Daemon {
 
         let document_handle = DocumentActorHandle::new(base_dir, init, is_host);
 
+        // Start socket listener.
+        let socket_path = socket_path.to_path_buf();
+        editor::spawn_socket_listener(socket_path, document_handle.clone()).await?;
+
         // Start file watcher.
         let base_dir = base_dir.to_path_buf();
         spawn_file_watcher(&base_dir, document_handle.clone()).await;
@@ -787,10 +791,6 @@ impl Daemon {
         if app_config.emit_join_code {
             put_secret_address_into_wormhole(&address).await;
         }
-
-        // Start socket listener.
-        let socket_path = socket_path.to_path_buf();
-        editor::spawn_socket_listener(socket_path, document_handle.clone()).await?;
 
         Ok(Self {
             document_handle,

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -68,12 +68,13 @@ pub async fn spawn_socket_listener(
     document_handle: DocumentActorHandle,
 ) -> Result<()> {
     // Make sure the parent directory of the socket is only accessible by the current user.
-    if let Err(description) = is_user_readable_only(&socket_path) {
+    /*if let Err(description) = is_user_readable_only(&socket_path) {
         panic!("{}", description);
-    }
+    }*/
 
     // Using the sandbox method here is technically unnecessary,
     // but we want to really run all path operations through the sandbox module.
+    // TODO: Use correct directory as guard.
     if sandbox::exists(Path::new("/"), Path::new(&socket_path))
         .expect("Failed to check existence of path")
     {

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -55,7 +55,7 @@ fn is_user_readable_only(socket_path: &Path) -> Result<()> {
     // Group and others should not have any permissions.
     let allowed_permissions = 0o77700u32;
     if current_permissions | allowed_permissions != allowed_permissions {
-        bail!("For security reasons, the parent directory of the socket must only be accessible by the current user");
+        bail!("For security reasons, the parent directory of the socket must only be accessible by the current user. Please run `chmod go-rwx {:?}`", parent_dir);
     }
     Ok(())
 }
@@ -68,9 +68,9 @@ pub async fn spawn_socket_listener(
     document_handle: DocumentActorHandle,
 ) -> Result<()> {
     // Make sure the parent directory of the socket is only accessible by the current user.
-    /*if let Err(description) = is_user_readable_only(&socket_path) {
+    if let Err(description) = is_user_readable_only(&socket_path) {
         panic!("{}", description);
-    }*/
+    }
 
     // Using the sandbox method here is technically unnecessary,
     // but we want to really run all path operations through the sandbox module.

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -44,46 +44,6 @@ impl Encoder<EditorProtocolObject> for EditorProtocolCodec {
     }
 }
 
-fn get_fallback_socket_dir() -> String {
-    let socket_dir = format!(
-        "/tmp/ethersync-{}",
-        std::env::var("USER").expect("$USER should be set")
-    );
-    if !fs::exists(&socket_dir).expect("Should be able to test for existence of directory in /tmp")
-    {
-        fs::create_dir(&socket_dir).expect("Should be able to create a directory in /tmp");
-        let permissions = fs::Permissions::from_mode(0o700);
-        fs::set_permissions(&socket_dir, permissions)
-            .expect("Should be able to set permissions for a directory we just created");
-    }
-    socket_dir
-}
-
-fn is_valid_socket_name(socket_name: &Path) -> Result<()> {
-    if socket_name.components().count() != 1 {
-        bail!("The socket name must be a single path component");
-    }
-    if let std::path::Component::Normal(_) = socket_name
-        .components()
-        .next()
-        .expect("The component count of socket_name was previously checked to be non-empty")
-    {
-        // All good :)
-    } else {
-        bail!("The socket name must be a plain filename");
-    }
-    Ok(())
-}
-
-pub fn get_socket_path(socket_name: &Path) -> PathBuf {
-    let socket_dir = std::env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| get_fallback_socket_dir());
-    let socket_dir = Path::new(&socket_dir);
-    if let Err(description) = is_valid_socket_name(socket_name) {
-        panic!("{}", description);
-    }
-    socket_dir.join(socket_name)
-}
-
 fn is_user_readable_only(socket_path: &Path) -> Result<()> {
     let parent_dir = socket_path
         .parent()

--- a/daemon/src/logging.rs
+++ b/daemon/src/logging.rs
@@ -13,7 +13,7 @@ pub fn initialize() -> Result<()> {
 
     if simplified_logging {
         let subscriber = FmtSubscriber::builder()
-            .with_env_filter(EnvFilter::new("ethersync=info"))
+            .with_env_filter(EnvFilter::new("ethersync=info,fuzzer=info"))
             .without_time()
             .with_level(false)
             .with_target(false)

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -180,11 +180,11 @@ async fn wait_for_ctrl_c() {
 }
 
 fn ask(question: &str) -> Result<bool> {
-    print!("{} (y/n): ", question);
+    print!("{} (y/N): ", question);
     std::io::stdout().flush()?;
     let mut lines = std::io::stdin().lines();
     if let Some(Ok(line)) = lines.next() {
-        match line.as_str() {
+        match line.to_lowercase().as_str() {
             "y" | "yes" => Ok(true),
             _ => Ok(false),
         }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -17,10 +17,6 @@ use tracing::debug;
 mod jsonrpc_forwarder;
 
 // TODO: Define these constants in the ethersync crate, and use them here.
-const DEFAULT_SOCKET_NAME: &str = "socket";
-const ETHERSYNC_CONFIG_DIR: &str = ".ethersync";
-const ETHERSYNC_CONFIG_FILE: &str = "config";
-
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -57,7 +53,7 @@ enum Commands {
 }
 
 fn has_ethersync_directory(dir: &Path) -> bool {
-    let ethersync_dir = dir.join(ETHERSYNC_CONFIG_DIR);
+    let ethersync_dir = dir.join(config::CONFIG_DIR);
     // Using the sandbox method here is technically unnecessary,
     // but we want to really run all path operations through the sandbox module.
     sandbox::exists(dir, &ethersync_dir).expect("Failed to check") && ethersync_dir.is_dir()
@@ -81,13 +77,11 @@ async fn main() -> Result<()> {
 
     let directory = get_directory(cli.directory)?;
 
-    let config_file = directory
-        .join(ETHERSYNC_CONFIG_DIR)
-        .join(ETHERSYNC_CONFIG_FILE);
+    let config_file = directory.join(config::CONFIG_DIR).join(config::CONFIG_FILE);
 
     let socket_path = directory
-        .join(ETHERSYNC_CONFIG_DIR)
-        .join(DEFAULT_SOCKET_NAME);
+        .join(config::CONFIG_DIR)
+        .join(config::DEFAULT_SOCKET_NAME);
 
     match cli.command {
         Commands::Share { .. } | Commands::Join { .. } => {
@@ -149,7 +143,7 @@ fn get_directory(directory: Option<PathBuf>) -> Result<PathBuf> {
     if !has_ethersync_directory(&directory) {
         bail!(
             "No {}/ found in {} (create that directory to Ethersync-enable the project)",
-            ETHERSYNC_CONFIG_DIR,
+            config::CONFIG_DIR,
             directory.display()
         );
     }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -128,7 +128,7 @@ async fn main() -> Result<()> {
                 }
             }
 
-            print_starting_info(&directory);
+            debug!("Starting Ethersync on {}.", directory.display());
             let _daemon = Daemon::new(app_config, &socket_path, &directory, init_doc).await?;
             wait_for_ctrl_c().await;
         }
@@ -154,10 +154,6 @@ fn get_directory(directory: Option<PathBuf>) -> Result<PathBuf> {
         );
     }
     Ok(directory)
-}
-
-fn print_starting_info(directory: &Path) {
-    debug!("Starting Ethersync on {}.", directory.display());
 }
 
 async fn wait_for_ctrl_c() {

--- a/daemon/src/sandbox.rs
+++ b/daemon/src/sandbox.rs
@@ -12,6 +12,7 @@ use ignore::WalkBuilder;
 use path_clean::PathClean;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 pub fn read_file(absolute_base_dir: &Path, absolute_file_path: &Path) -> Result<Vec<u8>> {
@@ -67,7 +68,9 @@ pub fn remove_file(absolute_base_dir: &Path, absolute_file_path: &Path) -> Resul
 pub fn create_dir(absolute_base_dir: &Path, absolute_dir_path: &Path) -> Result<()> {
     let canonical_dir_path =
         check_inside_base_dir_and_canonicalize(absolute_base_dir, absolute_dir_path)?;
-    std::fs::create_dir(canonical_dir_path)?;
+    std::fs::create_dir(&canonical_dir_path)?;
+    let permissions = fs::Permissions::from_mode(0o700);
+    std::fs::set_permissions(canonical_dir_path, permissions)?;
     Ok(())
 }
 

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -67,12 +67,12 @@ local function process_operation_for_editor(method, parameters)
 end
 
 -- Connect to the daemon.
-local function connect()
+local function connect(directory)
     if client then
         client.terminate()
     end
 
-    local params = { "client" }
+    local params = { "client", "--directory", directory }
 
     local dispatchers = {
         notification = function(method, notification_params)
@@ -100,26 +100,26 @@ local function connect()
     print("Connected to Ethersync daemon!")
 end
 
-local function is_ethersync_enabled(filename)
-    -- Recusively scan up directories. If we find an .ethersync directory on any level, return true.
+local function find_directory(filename)
+    -- Recusively scan up directories. If we find an .ethersync directory on any level, return its parent, and nil otherwise.
     if vim.version().api_level < 12 then
         -- In Vim 0.9, do it manually.
         local path = filename
         while true do
             if vim.fn.isdirectory(path .. "/.ethersync") == 1 then
-                return true
+                return path
             end
             local parentPath = vim.fn.fnamemodify(path, ":h")
             if parentPath == path then
                 -- We can't progress further like this.
-                return false
+                return nil
             else
                 path = parentPath
             end
         end
     else
         -- In Vim 0.10, this function is available.
-        return vim.fs.root(filename, ".ethersync") ~= nil
+        return vim.fs.root(filename, ".ethersync")
     end
 end
 
@@ -164,12 +164,13 @@ local function on_buffer_open()
     local filename = vim.fn.expand("%:p")
     debug("on_buffer_open: " .. filename)
 
-    if not is_ethersync_enabled(filename) then
+    local directory = find_directory(filename)
+    if not directory then
         return
     end
 
     if not client then
-        connect()
+        connect(directory)
     end
 
     local uri = "file://" .. filename
@@ -199,7 +200,7 @@ local function on_buffer_close()
     local closed_file = vim.fn.expand("<afile>:p")
     debug("on_buffer_close: " .. closed_file)
 
-    if not is_ethersync_enabled(closed_file) then
+    if not find_directory(closed_file) then
         return
     end
 

--- a/vscode-plugin/package-lock.json
+++ b/vscode-plugin/package-lock.json
@@ -1,12 +1,13 @@
 {
     "name": "ethersync",
-    "version": "0.0.1",
+    "version": "0.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ethersync",
-            "version": "0.0.1",
+            "version": "0.2.1",
+            "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "async-mutex": "^0.5.0",
                 "vscode-jsonrpc": "^8.2.0"
@@ -23,7 +24,7 @@
                 "typescript": "^5.4.5"
             },
             "engines": {
-                "vscode": "^1.88.0"
+                "vscode": "^1.89.0"
             }
         },
         "node_modules/@bcoe/v8-coverage": {


### PR DESCRIPTION
This has the advantage that two daemons started on different directories will never clash - useful for multi-daemon scenarios, and for local testing.

One downside is that the editor plugins need to do a bit more work: They need to figure out which directory to start `ethersync client` in. However, our two plugins already had all the code required to find it, because they needed to scan for the .ethersync directory anyway.

The --directory flag would be global for all subcommands.

What do you think? I think this is worth the additional editor code, and simplifies things a lot.

- [x] Update documentation (aka delete all references to sockets ever, hopefully!)
- [x] Provide a smooth upgrade path? (Currently, it's important to do `chmod go-rwx .ethersync`.)
	- Maybe we should drop this permission requirement now? I think basically all other programs leave it up to the user to set permissions on files in their own directories like they want... I did that for now in this PR.

Possible refactorings:

- [x] Move the constants like DEFAULT_SOCKET_NAME out into the `ethersync` crate, and use them everywhere else.