### PR TITLE
Make CI builds faster

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -20,6 +20,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_PROFILE_TEST_DEBUG: 0 # See https://corrode.dev/blog/tips-for-faster-ci-builds/
 
 defaults:
   run:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -25,6 +25,7 @@ jobs:
   build_and_test:
     name: Run tests
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         nvim-version: [v0.9.5, v0.10.1]

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -39,12 +39,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Rust toolchain
         run: rustup toolchain install stable --profile minimal
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/cache@v4
         with:
-          workspaces: |
-            daemon
-            daemon/integration-tests
-          cache-on-failure: true
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            daemon/target/
+            daemon/integration-tests/target/
+          key: ${{ runner.os }}-cargo
       - name: Build Ethersync
         run: cargo build --release
       - name: Add ethersync binary to PATH

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -21,6 +21,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+defaults:
+  run:
+    working-directory: ./daemon
+
 jobs:
   build_and_test:
     name: Run tests
@@ -30,9 +34,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         nvim-version: [v0.9.5, v0.10.1]
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: ./daemon
     steps:
       - uses: actions/checkout@v4
       - name: Set up Rust toolchain
@@ -76,9 +77,6 @@ jobs:
   check_formatting:
     name: Check Rust formatting
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./daemon
     steps:
       - uses: actions/checkout@v4
       - run: cargo fmt --check

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -20,7 +20,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0 # See https://corrode.dev/blog/tips-for-faster-rust-compile-times/
 
 jobs:
   build_and_test:
@@ -39,7 +38,10 @@ jobs:
         run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: "daemon"
+          workspaces: |
+            daemon
+            daemon/integration-tests
+          cache-on-failure: true
       - name: Build Ethersync
         run: cargo build --release
       - name: Add ethersync binary to PATH


### PR DESCRIPTION
This improves a couple of things about the way we build and test on the CI. A huge part of our CI time is spent compiling our dependencies, so:

- If testing fails, still cache the compiled dependencies.
- Cache dependencies of the integration-test crate, as well.
- If one of our matrix tests fails, don't abort the others (I think I would still be interested to see the other results!)
- In the `test` profile, don't generate debug information (would make output larger)

Full rebuild:

![image](https://github.com/user-attachments/assets/bdd496b6-e0b8-4824-bf09-07c1bb19da1e)

Using the cached dependencies:

![image](https://github.com/user-attachments/assets/4dab5d4a-cf70-4b33-a71e-7ce115a3c354)

Some more thoughts:

- I tried installing the mold linker, but it didn't seem to make a difference here.
- The cache action will not be used as soon as there's a change in Cargo.toml or Cargo.lock. I wonder whether we could simplify it to *always* cache the target directories. That seems more useful for us, but we can do it later!