### PR TITLE
Ephemeral cursors, part 2

### DIFF
--- a/daemon/src/editor_connection.rs
+++ b/daemon/src/editor_connection.rs
@@ -65,21 +65,19 @@ impl EditorConnection {
                     vec![]
                 }
             }
-            ComponentMessage::Cursor(CursorState {
-                file_path,
-                ranges,
-                name,
+            ComponentMessage::Cursor {
                 cursor_id,
-            }) => {
-                let uri = AbsolutePath::from_parts(&self.base_dir, file_path)
+                cursor_state,
+            } => {
+                let uri = AbsolutePath::from_parts(&self.base_dir, &cursor_state.file_path)
                     .expect("Should be able to construct absolute URI")
                     .to_file_uri();
 
                 vec![EditorProtocolMessageToEditor::Cursor {
-                    name: name.clone(),
                     userid: cursor_id.clone(),
+                    name: cursor_state.name.clone(),
                     uri: uri.to_string(),
-                    ranges: ranges.clone(),
+                    ranges: cursor_state.ranges.clone(),
                 }]
             }
             _ => {
@@ -228,12 +226,14 @@ impl EditorConnection {
                     .map_err(anyhow_err_to_protocol_err)?;
 
                 Ok((
-                    ComponentMessage::Cursor(CursorState {
+                    ComponentMessage::Cursor {
                         cursor_id: self.id.clone(),
-                        name: env::var("USER").ok(),
-                        file_path: relative_path,
-                        ranges: ranges.clone(),
-                    }),
+                        cursor_state: CursorState {
+                            name: env::var("USER").ok(),
+                            file_path: relative_path.clone(),
+                            ranges: ranges.clone(),
+                        },
+                    },
                     vec![],
                 ))
             }

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -6,7 +6,7 @@
 //! A peer is another daemon. This module is all about daemon to daemon communication.
 
 use crate::daemon::{DocMessage, DocumentActorHandle};
-use crate::types::CursorState;
+use crate::types::CursorStateWithSequenceNumber;
 use anyhow::{Context, Result};
 use automerge::sync::{Message as AutomergeSyncMessage, State as SyncState};
 use iroh::SecretKey;
@@ -30,7 +30,7 @@ enum PeerMessage {
     Sync(Vec<u8>),
     /// The Ephemeral message currently is used for cursor messages, but can later be used for
     /// other things that should not be persisted.
-    Ephemeral(CursorState),
+    Ephemeral(CursorStateWithSequenceNumber),
 }
 
 #[derive(Clone)]

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -97,16 +97,16 @@ pub type CursorId = String;
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct CursorState {
-    pub cursor_id: CursorId,
     pub name: Option<String>,
     pub file_path: RelativePath,
     pub ranges: Vec<Range>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
-pub struct CursorStateWithSequenceNumber {
-    pub cursor_state: CursorState,
+pub struct EphemeralMessage {
+    pub cursor_id: CursorId,
     pub sequence_number: usize,
+    pub cursor_state: CursorState,
 }
 
 pub enum PatchEffect {
@@ -188,7 +188,10 @@ pub enum ComponentMessage {
         file_path: RelativePath,
         delta: TextDelta,
     },
-    Cursor(CursorState),
+    Cursor {
+        cursor_id: CursorId,
+        cursor_state: CursorState,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -93,7 +93,7 @@ impl FileTextDelta {
 }
 
 type DocumentUri = String;
-type CursorId = String;
+pub type CursorId = String;
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct CursorState {
@@ -101,6 +101,12 @@ pub struct CursorState {
     pub name: Option<String>,
     pub file_path: RelativePath,
     pub ranges: Vec<Range>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+pub struct CursorStateWithSequenceNumber {
+    pub cursor_state: CursorState,
+    pub sequence_number: usize,
 }
 
 pub enum PatchEffect {

--- a/vim-plugin/lua/cursor.lua
+++ b/vim-plugin/lua/cursor.lua
@@ -220,6 +220,8 @@ function M.track_cursor(bufnr, callback)
             callback(ranges)
         end,
     })
+    -- Trigger the callback above once, to send initial cursor position.
+    vim.api.nvim_exec_autocmds("CursorMoved", {})
 end
 
 function M.jump_to_cursor()


### PR DESCRIPTION
This is based on #286, and adds some remaining bits and pieces:

- Cache cursor positions known to a peer, using the cursor ID and a (incrementing) sequence number.
- When receiving a cursor information from a peer, only do something if it's newer than the last known one.
- Send known cursor positions to editor when they join (#44).

I refactored the involved types a bit, thinking that neither the cursor ID (maybe another name would be better? client ID?) nor the sequence number really belong to the "payload" = the cursor selection information. But I'm not too sure/confident about this change.