### PR TITLE
vim: When pressing o on a line, edit should be placed in the new line

### DIFF
--- a/daemon/integration-tests/tests/vim-plugin.rs
+++ b/daemon/integration-tests/tests/vim-plugin.rs
@@ -326,9 +326,6 @@ async fn vim_sends_correct_delta() {
 
     assert_vim_input_yields_replacements("a", "o", vec![replace_ed((0, 1), (0, 1), "\n")]).await;
 
-    assert_vim_input_yields_replacements("eins\ntwo", "jo", vec![replace_ed((1, 3), (1, 3), "\n")])
-        .await;
-
     assert_vim_input_yields_replacements(
         "eins\ntwo\n",
         "jo",

--- a/vim-plugin/lua/changetracker.lua
+++ b/vim-plugin/lua/changetracker.lua
@@ -46,7 +46,7 @@ function M.track_changes(buffer, callback)
             -- TODO: optimize with a cache
             local curr_lines = get_all_lines_respecting_eol(buffer)
 
-            -- Special case: When deleting the entire content, when of 'eol' is on, there
+            -- Special case: When deleting the entire content, when 'eol' is on, there
             -- will still be a "virtual line" after the current empty line: The file content will be "\n".
             -- So new_last_line should not be 0, but 1!
             if vim.bo[buffer].eol and #curr_lines == 2 and curr_lines[1] == "" and last_line == 1 then
@@ -121,6 +121,7 @@ function M.track_changes(buffer, callback)
                     end
                 end
             else
+                -- The range does not extend past the visible buffer lines (diff.range["end"].line < #prev_lines).
                 -- We might still want to make the delta prettier.
                 -- TODO: Integrate these cases in the above if branches somehow?
                 if
@@ -143,7 +144,6 @@ function M.track_changes(buffer, callback)
                 then
                     -- Range ends on the beginning of a line, but the replacement ends with a newline.
                     -- This newline is redundant, and leads to less-pretty diffs. Remove it.
-
                     diff.text = string.sub(diff.text, 1, -2)
                     diff.range["end"].line = diff.range["end"].line - 1
                     diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1])


### PR DESCRIPTION
Instead of placing the edit after the previous one. This fixes #288.

Strategy: Add a new "fix" condition, where we check for newlines at the beginning of the replacement. Also, when 'eol' is on, pretend there are empty lines for compute_diff. This leads to prettier diffs overall. We need that differentiation because otherwise, for buffer content "x", when pressing o, we have no chance to insert in the next line (which we may do when 'eol' is on!)