### PR TITLE
When accepting a connection fails, log error instead of panicking

### DIFF
--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -120,7 +120,7 @@ impl P2PActor {
                         });
                     }
                     Err(err) => {
-                        panic!("Error while accepting peer connection: {err}");
+                        error!("Error while accepting peer connection: {err}");
                     }
                 }
             }


### PR DESCRIPTION
The most likely reason is someone talking trash to the QUIC port. No reason for us to crash.

This fixes #289.