### PR TITLE
vim: Don't print message that we're disabling 'autoread' on each startup

### DIFF
--- a/book/src/neovim.md
+++ b/book/src/neovim.md
@@ -55,3 +55,7 @@ ln -s $PWD/vim-plugin $HOME/.local/share/nvim/site/pack/plugins/start/ethersync
 ## Confirm the installation
 
 To confirm that the plugin is installed, try running the `:EthersyncInfo` command in Neovim. It should show the message "Not connected to Ethersync daemon."
+
+## Note: The plugin will set the 'autoread' option to "off".
+
+This is because in Ethersync's current model, once an editor opens a file, it takes "ownership" of it – external edits should not be taken into account. Thus, re-loading external changes into the buffer is not desirable.

--- a/vim-plugin/plugin/ethersync.lua
+++ b/vim-plugin/plugin/ethersync.lua
@@ -7,9 +7,6 @@ local changetracker = require("changetracker")
 local cursor = require("cursor")
 local debug = require("logging").debug
 
--- We only want to communicate a possibly annoying info once.
-local did_print_autoread_info = false
-
 -- JSON-RPC connection.
 local client
 
@@ -151,10 +148,6 @@ end
 -- For the conflicting case, we prevent a popup dialog by setting the FileChangedShell autocommand below.
 local function ensure_autoread_is_off()
     if vim.o.autoread then
-        if not did_print_autoread_info then
-            print("Ethersync works better when autoread is off, so we're disabling it for you (in Ethersync buffers).")
-            did_print_autoread_info = true
-        end
         vim.bo.autoread = false
     end
 end


### PR DESCRIPTION
Move the information into the documentation. I think it belongs there, it's such a minor issue that we don't need to display it at every startup.

In addition, in narrow terminal windows, the message forces the user to press "Enter" to acknowledge it, which is probably more annoying than being surprised by the changed option.