### PR TITLE
vim: Don't send out deltas that don't change anything

### DIFF
--- a/daemon/integration-tests/tests/vim-plugin.rs
+++ b/daemon/integration-tests/tests/vim-plugin.rs
@@ -246,8 +246,6 @@ async fn vim_sends_correct_delta() {
         "i<CR><BS>",
         vec![
             replace_ed((0, 0), (0, 0), "\n"),
-            // no-op: Copy nothing to previous line.
-            replace_ed((0, 0), (0, 0), ""),
             replace_ed((0, 0), (1, 0), ""),
         ],
     )
@@ -263,8 +261,6 @@ async fn vim_sends_correct_delta() {
             replace_ed((0, 0), (0, 1), ""),
             replace_ed((0, 0), (0, 0), "x"),  // d: "x\n"
             replace_ed((0, 1), (0, 1), "\n"), // d: "x\n\n"
-            // no-op: Copy nothing to previous line.
-            replace_ed((0, 1), (0, 1), ""),
             replace_ed((1, 0), (2, 0), ""),
         ],
     )

--- a/vim-plugin/lua/changetracker.lua
+++ b/vim-plugin/lua/changetracker.lua
@@ -23,6 +23,12 @@ local function get_all_lines_respecting_eol(buffer)
     return lines
 end
 
+local function is_empty(diff)
+    return diff.text == ""
+        and diff.range["start"].line == diff.range["end"].line
+        and diff.range["start"].character == diff.range["end"].character
+end
+
 -- Subscribes the callback to changes for a given buffer id and reports with a delta.
 --
 -- The delta can be expected to be in the format as specified in the daemon-editor protocol.
@@ -151,6 +157,10 @@ function M.track_changes(buffer, callback)
             end
 
             prev_lines = curr_lines
+
+            if is_empty(diff) then
+                return
+            end
 
             local delta = {
                 {


### PR DESCRIPTION
We saw these when pressing backspace on an empty line, or when using formatters, see #290.