### PR TITLE
vscode: Improve display of remote cursors

### DIFF
--- a/vscode-plugin/src/cursor.ts
+++ b/vscode-plugin/src/cursor.ts
@@ -12,7 +12,7 @@ const selectionDecorationType = vscode.window.createTextEditorDecorationType({
     before: {
         color: "#548abf",
         contentText: "ᛙ",
-        margin: "0px 0px 0px -0.5ch",
+        margin: "0px 0px 0px -0.35ch",
         textDecoration: "font-weight: bold; position: absolute; top: 0; font-size: 200%; z-index: 0;",
     },
 })

--- a/vscode-plugin/src/cursor.ts
+++ b/vscode-plugin/src/cursor.ts
@@ -20,12 +20,12 @@ const selectionDecorationType = vscode.window.createTextEditorDecorationType({
 interface RemoteCursor {
     name: string
     uri: vscode.Uri
-    selection: vscode.Selection
+    selection: vscode.DecorationOptions
 }
 
 let cursors: Map<string, RemoteCursor[]> = new Map()
 
-export function setCursor(userid: string, name: string, uri: vscode.Uri, selections: vscode.Selection[]) {
+export function setCursor(userid: string, name: string, uri: vscode.Uri, selections: vscode.DecorationOptions[]) {
     let usersCursors = cursors.get(userid)
     if (usersCursors) {
         // Remove all decorations by this user.
@@ -58,8 +58,8 @@ export function getCursorInfo(): string {
         let message: string[] = []
         cursors.forEach((usersCursors, _userid) => {
             for (let cursor of usersCursors) {
-                let line1 = cursor.selection.active.line + 1
-                let line2 = cursor.selection.anchor.line + 1
+                let line1 = cursor.selection.range.start.line + 1
+                let line2 = cursor.selection.range.end.line + 1
                 if (line1 > line2) {
                     ;[line1, line2] = [line2, line1]
                 }

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -10,7 +10,7 @@ import * as path from "path"
 import * as fs from "fs"
 var Mutex = require("async-mutex").Mutex
 
-import {setCursor, getCursorInfo} from "./cursor"
+import {setCursor, getCursorInfo, drawCursors} from "./cursor"
 
 function findEthersyncDirectory(dir: string) {
     if (fs.existsSync(path.join(dir, ".ethersync"))) {
@@ -54,7 +54,7 @@ interface Cursor {
 }
 
 interface CursorFromDaemon {
-    userid: number
+    userid: string
     name?: string
     uri: string
     ranges: Range[]
@@ -440,6 +440,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.workspace.onDidOpenTextDocument(processUserOpen),
         vscode.workspace.onDidCloseTextDocument(processUserClose),
         vscode.window.onDidChangeTextEditorSelection(processSelection),
+        vscode.window.onDidChangeActiveTextEditor(drawCursors),
         vscode.commands.registerCommand("ethersync.showCursors", showCursorNotification),
     )
 

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -232,9 +232,14 @@ async function processCursorFromDaemon(cursor: CursorFromDaemon) {
     const document = documentForUri(uri)
 
     try {
-        let selections: vscode.Selection[] = []
+        let selections: vscode.DecorationOptions[] = []
         if (document) {
-            selections = cursor.ranges.map((r) => ethersyncRangeToVSCodeRange(document, r)).map(vsCodeRangeToSelection)
+            selections = cursor.ranges.map((r) => ethersyncRangeToVSCodeRange(document, r)).map(vsCodeRangeToSelection).map(s => {
+                return {
+                    range: s,
+                    hoverMessage: cursor.name,
+                }
+            })
         }
         setCursor(cursor.userid, cursor.name || "anonymous", vscode.Uri.parse(uri), selections)
     } catch {


### PR DESCRIPTION
Addresses some points from #206:

- Position remote cursors between characters better
- Improve displaying of remote cursors (allow multiple ones, update them when switching between files)
- Show name of remote cursors in hover text

Still missing:

- [ ] Save cursor for unopened file (currently not possible, because we need to transform from UTF-32 positions to UTF-16 positions…)
- [ ] Respect the "direction" of a selection, and draw the active end there