### PR TITLE
fuzzer: disable ShaDa file for nvim actor

### DIFF
--- a/daemon/integration-tests/src/actors.rs
+++ b/daemon/integration-tests/src/actors.rs
@@ -39,7 +39,7 @@ impl Neovim {
         let handler = Dummy::new();
         let mut cmd = tokio::process::Command::new("nvim");
         cmd.arg("--headless").arg("--embed");
-        // Disable ShaDa file.
+        // Disable ShaDa files, to prevent CI failures related to them.
         cmd.arg("-i").arg("NONE");
         let (nvim, _, _) = new_child_cmd(&mut cmd, handler).await.unwrap();
 


### PR DESCRIPTION
Add command line flag to disable the ShaDa file.

See https://neovim.io/doc/user/starting.html#-i and https://neovim.io/doc/user/starting.html#_shada-(

This prevents certain CI failures, where for some reason the ShaDa file was corrupted.

Fixes #315.