### PR TITLE
Give better error message when clients try to open files outside base_dir

### DIFF
--- a/book/src/workarounds.md
+++ b/book/src/workarounds.md
@@ -12,3 +12,8 @@ Some things about Ethersync are currently still a bit annoying. Let us show you 
 ## Restarting the daemon requires restarting the editor
 
 The editor plugins currently only try to connect to Ethersync when they first start. If you need to restart the daemon for any reason, you will also need to restart all open editors to reconnect.
+
+## Can't work on files from multiple projects in one editor session
+
+The editor plugins currently only connect to a single daemon, when the first file from a shared directory is opened.
+To work on files from another project, either use a second editor instance, or close the first one.

--- a/daemon/src/path.rs
+++ b/daemon/src/path.rs
@@ -68,7 +68,7 @@ impl RelativePath {
         })?;
         let relative_path = path.strip_prefix(&project_dir).with_context(|| {
             format!(
-                "Failed to strip project directory '{}' from path {path}",
+                "The path {path} is not in the project directory '{}'. Your plugin probably doesn't support opening files from multiple Ethersync directories.",
                 project_dir.display()
             )
         })?;


### PR DESCRIPTION
This addresses #279.

- [x] Mention this in the documentation