### PR TITLE
fuzzer: do not use Neovim swapfile to prevent CI failure

### DIFF
--- a/daemon/integration-tests/src/actors.rs
+++ b/daemon/integration-tests/src/actors.rs
@@ -41,6 +41,8 @@ impl Neovim {
         cmd.arg("--headless").arg("--embed");
         // Disable ShaDa files, to prevent CI failures related to them.
         cmd.arg("-i").arg("NONE");
+        // Disable Swap file, to prevent CI failures related to them.
+        cmd.arg("-n");
         let (nvim, _, _) = new_child_cmd(&mut cmd, handler).await.unwrap();
 
         // We canonicalize the path here, because on macOS, TempDir gives us paths in /var/, which


### PR DESCRIPTION
This is the lazy quickfix approach. I don't understand why it's necessary yet.

Fixes #335
