### PR TITLE
Support binary files

### DIFF
--- a/book/src/ignored-files.md
+++ b/book/src/ignored-files.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 # Ignored files
 
 Some files and directories are ignored by default. Also you have the option to specify files that should be ignored.
-Files that might contain sensitive information, like secrets, that should not be shared with your peers. Also Ethersync doesn't handle binary files, so maybe it makes sense to exclude them too.
+Files that might contain sensitive information, like secrets, that should not be shared with your peers.
 
 Ethersync
 - ignores `.git` and everything in it.

--- a/book/src/system-overview.md
+++ b/book/src/system-overview.md
@@ -10,7 +10,6 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 Ethersync is a system for real-time local-first collaboration on text files, where
 - *real-time* means that edits and cursor movements should appear immediately while you are in a connection with your peer
 - *local-first* means that it's also possible to continue working on the project while you're (temporarily) offline
-- and the collaboration is restricted to *text-files* only (unfortunately, we don't support docx, xlsx, images, or other binary files yet).
 
 Here's a diagram of the components that are involved:
 

--- a/book/src/workarounds.md
+++ b/book/src/workarounds.md
@@ -17,3 +17,15 @@ The editor plugins currently only try to connect to Ethersync when they first st
 
 The editor plugins currently only connect to a single daemon, when the first file from a shared directory is opened.
 To work on files from another project, either use a second editor instance, or close the first one.
+
+## Opening binary files in editors converts them to UTF-8
+
+This happens because most editors are not well-equipped for editing binary data directly.
+
+To edit a binary file together, first convert to a hexdump like this (`-R never` is to disable color output):
+
+    xxd -R never binary_file > binary_file.hex
+
+Then, edit the `.hex` file collaboratively. Finally, convert back to a binary:
+
+    xxd -r binary_file.hex > binary_file

--- a/book/src/workarounds.md
+++ b/book/src/workarounds.md
@@ -20,7 +20,7 @@ To work on files from another project, either use a second editor instance, or c
 
 ## Opening binary files in editors converts them to UTF-8
 
-This happens because most editors are not well-equipped for editing binary data directly.
+This happens because most editors are [not well-equipped](https://github.com/ethersync/ethersync/issues/360) for editing binary data directly.
 
 To edit a binary file together, first convert to a hexdump like this (`-R never` is to disable color output):
 

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -427,7 +427,7 @@ impl DocumentActor {
                 let relative_file_path = RelativePath::try_from_path(&self.base_dir, &file_path)
                     .expect("Watcher event should have a path within the base directory");
                 if self.owns(&relative_file_path) {
-                    self.crdt_doc.remove_text(&relative_file_path);
+                    self.crdt_doc.remove_file(&relative_file_path);
                     let _ = self.doc_changed_ping_tx.send(());
                 }
             }
@@ -619,7 +619,7 @@ impl DocumentActor {
                 warn!(
                         "File {relative_file_path} exists in the CRDT, but not on disk. Deleting from CRDT."
                     );
-                self.crdt_doc.remove_text(&relative_file_path);
+                self.crdt_doc.remove_file(&relative_file_path);
             }
         }
         let _ = self.doc_changed_ping_tx.send(());

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -663,6 +663,8 @@ impl DocumentActor {
                 } else {
                     // The file doesn't exist yet - create it in the Automerge document.
                     self.crdt_doc.initialize_text(content, file_path);
+                    let _ = self.doc_changed_ping_tx.send(());
+                    self.write_file(file_path);
                 };
             }
             ComponentMessage::Close { file_path } => {

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -236,6 +236,21 @@ impl DocumentActor {
                                 warn!("Failed to remove file {file_path}: {err}");
                             });
                         }
+                        PatchEffect::FileBytes(file_path, bytes) => {
+                            let absolute_path = &self.absolute_path_for_file_path(&file_path);
+
+                            // If the file didn't exist before, log it.
+                            if !sandbox::exists(&self.base_dir, absolute_path)
+                                .expect("Failed to check for file existence before writing to it")
+                            {
+                                info!("Creating binary file {file_path}.");
+                            }
+
+                            sandbox::write_file(&self.base_dir, absolute_path, &bytes)
+                                .unwrap_or_else(|err| {
+                                    warn!("Failed to write to file {file_path}: {err}");
+                                });
+                        }
                         PatchEffect::NoEffect => {}
                     }
                 }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -549,12 +549,6 @@ impl DocumentActor {
             let abs_path = self.absolute_path_for_file_path(file_path);
             debug!("Writing to {abs_path}.");
 
-            // Create the parent directorie(s), if neccessary.
-            let parent_dir = abs_path.parent().unwrap();
-            sandbox::create_dir_all(&self.base_dir, parent_dir).unwrap_or_else(|_| {
-                panic!("Could not create parent directory {}", parent_dir.display())
-            });
-
             // If the file didn't exist before, log it.
             if !sandbox::exists(&self.base_dir, &abs_path)
                 .expect("Failed to check for file existence before writing to it")

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -164,14 +164,22 @@ impl Document {
         }
     }
 
-    pub fn remove_text(&mut self, file_path: &RelativePath) {
-        if self.text_obj(file_path).is_err() {
+    pub fn remove_file(&mut self, file_path: &RelativePath) {
+        let file_map = self
+            .top_level_map_obj("files")
+            .expect("Failed to get files Map");
+        if self
+            .doc
+            .get(file_map, file_path)
+            .expect("Failed to get file from doc")
+            .is_none()
+        {
             debug!("Failed to get {file_path} Text object, so I can't remove it from the CRDT.");
             return;
         };
 
         info!("Removing {file_path} from the Ethersync history.");
-        // TODO: Also remove it from ot server, if applicable
+
         let file_map = self
             .top_level_map_obj("files")
             .expect("Failed to get files Map object");

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -255,7 +255,14 @@ impl Document {
     }
 
     pub fn file_exists(&self, file_path: &RelativePath) -> bool {
-        self.text_obj(file_path).is_ok()
+        if let Ok(file_map) = self.top_level_map_obj("files") {
+            self.doc
+                .get(file_map, file_path)
+                .unwrap_or_else(|_| panic!("Failed to get {file_path} key from Automerge document"))
+                .is_some()
+        } else {
+            false
+        }
     }
 }
 

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -165,16 +165,8 @@ impl Document {
     }
 
     pub fn remove_file(&mut self, file_path: &RelativePath) {
-        let file_map = self
-            .top_level_map_obj("files")
-            .expect("Failed to get files Map");
-        if self
-            .doc
-            .get(file_map, file_path)
-            .expect("Failed to get file from doc")
-            .is_none()
-        {
-            debug!("Failed to get {file_path} Text object, so I can't remove it from the CRDT.");
+        if !self.file_exists(file_path) {
+            debug!("Failed to get {file_path} key object, so I can't remove it from the CRDT.");
             return;
         };
 
@@ -194,7 +186,7 @@ impl Document {
             .top_level_map_obj("files")
             .expect("Failed to get files Map object");
 
-        // If the content hasn't changed, don't write to the file.
+        // If the content hasn't changed, don't write to the file. This prevents irrelevant watcher events.
         if let Ok(Some((
             automerge::Value::Scalar(std::borrow::Cow::Borrowed(automerge::ScalarValue::Bytes(
                 current_bytes,

--- a/daemon/src/sandbox.rs
+++ b/daemon/src/sandbox.rs
@@ -22,6 +22,7 @@ pub fn read_file(absolute_base_dir: &Path, absolute_file_path: &Path) -> Result<
     Ok(bytes)
 }
 
+/// Writes content to a file, creating the parent directories, if they don't exist.
 pub fn write_file(
     absolute_base_dir: &Path,
     absolute_file_path: &Path,
@@ -29,6 +30,13 @@ pub fn write_file(
 ) -> Result<()> {
     let canonical_file_path =
         check_inside_base_dir_and_canonicalize(absolute_base_dir, absolute_file_path)?;
+
+    // Create the parent directorie(s), if neccessary.
+    let parent_dir = canonical_file_path
+        .parent()
+        .expect("Failed to get parent directory");
+    create_dir_all(absolute_base_dir, parent_dir).expect("Failed to create parent directory");
+
     fs::write(canonical_file_path, content)?;
     Ok(())
 }

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -433,8 +433,6 @@ impl TryFrom<Patch> for PatchEffect {
             ))
         }
 
-        let mut delta = TextDelta::default();
-
         if patch.path.is_empty() {
             return match patch.action {
                 PatchAction::PutMap { key, .. } => {
@@ -475,7 +473,10 @@ impl TryFrom<Patch> for PatchEffect {
                                 (automerge::Value::Object(automerge::ObjType::Text), _) => {
                                     // We return an empty delta on the new file, so that the file is created on disk when
                                     // synced over to another peer. TODO: Is this the best way to solve this?
-                                    Ok(PatchEffect::FileChange(FileTextDelta::new(path, delta)))
+                                    Ok(PatchEffect::FileChange(FileTextDelta::new(
+                                        path,
+                                        TextDelta::default(),
+                                    )))
                                 }
                                 (
                                     automerge::Value::Scalar(std::borrow::Cow::Owned(
@@ -513,6 +514,7 @@ impl TryFrom<Patch> for PatchEffect {
                         )),
                     }
                 } else if patch.path.len() == 2 {
+                    let mut delta = TextDelta::default();
                     match patch.action {
                         PatchAction::SpliceText { index, value, .. } => {
                             delta.retain(index);


### PR DESCRIPTION
Implements #192.

From manual testing, binary files now behave like text files.

For stress testing, I dropped a 1 GB video file in a directory, and this also worked. Initial syncing took maybe 30 seconds. Re-initiating a connection also. I think the code is currently not very optimized for this, and might touch the content of big files a bit more often than necessary. But I'd be fine with that, as a first step.