### PR TITLE
Ignore VCS directories, and new way of ignoring .ethersync

### DIFF
--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -135,7 +135,7 @@ pub fn has_git_remote(path: &Path) -> bool {
 }
 
 #[must_use]
-pub fn ethersync_directory_should_be_ignored_but_isnt(path: &Path) -> bool {
+fn ethersync_directory_should_be_ignored_but_isnt(path: &Path) -> bool {
     if let Ok(repo) = find_git_repo(path) {
         let ethersync_dir = path.join(CONFIG_DIR);
         return !repo
@@ -171,7 +171,7 @@ fn find_git_repo(path: &Path) -> Result<git2::Repository, git2::Error> {
     git2::Repository::discover(path)
 }
 
-pub fn add_ethersync_to_local_gitignore(directory: &Path) -> Result<()> {
+fn add_ethersync_to_local_gitignore(directory: &Path) -> Result<()> {
     let mut ignore_file_path = directory.join(CONFIG_DIR);
     ignore_file_path.push(".gitignore");
 
@@ -187,5 +187,12 @@ pub fn add_ethersync_to_local_gitignore(directory: &Path) -> Result<()> {
     let bytes_out = content.as_bytes();
     sandbox::write_file(directory, &ignore_file_path, bytes_out)?;
 
+    Ok(())
+}
+
+pub fn ensure_ethersync_is_ignored(directory: &Path) -> Result<()> {
+    if ethersync_directory_should_be_ignored_but_isnt(directory) {
+        add_ethersync_to_local_gitignore(directory)?;
+    }
     Ok(())
 }

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -171,20 +171,21 @@ fn find_git_repo(path: &Path) -> Result<git2::Repository, git2::Error> {
     git2::Repository::discover(path)
 }
 
-pub fn add_ethersync_to_global_gitignore() -> Result<()> {
-    let home_dir = std::env::home_dir().expect("Could not find home directory");
-    let git_config_dir = home_dir.join(".config/git");
-    let ignore_file_path = git_config_dir.join("ignore");
+pub fn add_ethersync_to_local_gitignore(directory: &Path) -> Result<()> {
+    let mut ignore_file_path = directory.join(CONFIG_DIR);
+    ignore_file_path.push(".gitignore");
 
-    sandbox::create_dir_all(&git_config_dir, &git_config_dir)?;
-    let bytes_in = sandbox::read_file(&git_config_dir, &ignore_file_path).unwrap_or_default();
+    // It's very unlikely that .ethersync/.gitignore will already contain something, but let's
+    // still append.
+    let bytes_in = sandbox::read_file(directory, &ignore_file_path).unwrap_or_default();
     let mut content = std::str::from_utf8(&bytes_in)?.to_string();
+
     if !content.is_empty() && !content.ends_with('\n') {
         content.push('\n');
     }
-    content.push_str(".ethersync/\n");
+    content.push_str("/*\n");
     let bytes_out = content.as_bytes();
-    sandbox::write_file(&git_config_dir, &ignore_file_path, bytes_out)?;
+    sandbox::write_file(directory, &ignore_file_path, bytes_out)?;
 
     Ok(())
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -93,10 +93,7 @@ async fn main() -> Result<()> {
                 );
             }
 
-            // Silently make sure that .ethersync is ignored.
-            if config::ethersync_directory_should_be_ignored_but_isnt(&directory) {
-                config::add_ethersync_to_local_gitignore(&directory)?;
-            }
+            config::ensure_ethersync_is_ignored(&directory)?;
 
             let mut init_doc = false;
             let mut app_config;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -93,13 +93,9 @@ async fn main() -> Result<()> {
                 );
             }
 
+            // Silently make sure that .ethersync is ignored.
             if config::ethersync_directory_should_be_ignored_but_isnt(&directory) {
-                if ask("Ethersync uses the directory .ethersync/ to store sensitive secrets. Add it to your global ~/.config/git/ignore?")? {
-                    config::add_ethersync_to_global_gitignore()?;
-                    info!("Added! Resuming launch.");
-                } else {
-                    bail!("Aborting launch. We *really* don't want you to accidentally commit your secrets. Add .ethersync/ to a (global or local) .gitignore and try again.");
-                }
+                config::add_ethersync_to_local_gitignore(&directory)?;
             }
 
             let mut init_doc = false;

--- a/daemon/src/sandbox.rs
+++ b/daemon/src/sandbox.rs
@@ -96,7 +96,7 @@ pub fn exists(absolute_base_dir: &Path, absolute_file_path: &Path) -> Result<boo
 }
 
 pub fn enumerate_non_ignored_files(absolute_base_dir: &Path) -> Vec<PathBuf> {
-    let ignored_things = [".git", ".ethersync"];
+    let ignored_things = [".ethersync", ".git", ".bzr", ".hg", ".jj", ".pijul", ".svn"];
 
     let walk = WalkBuilder::new(absolute_base_dir)
         .standard_filters(true)


### PR DESCRIPTION
See #364 and #365.