### PR TITLE
vscode: Don't try to auto-save empty files

### DIFF
--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -442,7 +442,11 @@ function processUserEdit(event: vscode.TextDocumentChangeEvent) {
 
                 // Attempt auto-save to avoid the situation where one user closes a modified
                 // document without saving, which will cause VS Code to undo the dirty changes.
-                document.save()
+                // If the document is empty, don't save - this will trigger a
+                // "The content of the file is newer." warning.
+                if (document.getText() !== "") {
+                    document.save()
+                }
             })
             .catch((e: Error) => {
                 vscode.window.showErrorMessage(`Error while sending edit to Ethersync daemon: ${e}`)


### PR DESCRIPTION
For unknown reasons, when overwriting an empty file with another empty file, VS Code will complain: "The content of the file is newer."

Upon quick testing, I found no problem when closing the file in that state.

Fixes #358.