### PR TITLE
vscode: Instead of expecting certain remote edits, expect their result

### DIFF
--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -44,7 +44,8 @@
                             }
                         },
                         "required": [
-                            "cmd", "rootMarkers"
+                            "cmd",
+                            "rootMarkers"
                         ]
                     },
                     "default": {

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -403,18 +403,14 @@ function processUserClose(document: vscode.TextDocument) {
 
 function isRemoteEdit(event: vscode.TextDocumentChangeEvent): boolean {
     let actualContent = event.document.getText()
-    if (actualContent === expectedContentAfterRemoteEdit) {
-        expectedContentAfterRemoteEdit = null
-        return true
-    } else {
-        return false
-    }
+    return actualContent === expectedContentAfterRemoteEdit
 }
 
 // NOTE: We might get multiple events per document.version,
 // as the _state_ of the document might change (like isDirty).
 function processUserEdit(event: vscode.TextDocumentChangeEvent) {
     if (isRemoteEdit(event)) {
+        expectedContentAfterRemoteEdit = null
         debug("Ignoring remote event (we have caused it)")
         return
     }


### PR DESCRIPTION
When a remote edit replaces "x" with "XxX", VS Code will see a
TextDocumentChangeEvent that inserts two X's around the x. Because of
that, it's not possible to directly compare the edits.

Here's a proposed solution: Store the expected resulting content of the
document after the remote edit, then see if a local edit results in that
content.