### PR TITLE
nvim: automatically unfollow as soon as the user type something

### DIFF
--- a/nvim-plugin/README.md
+++ b/nvim-plugin/README.md
@@ -38,7 +38,6 @@ Usually, you will add the string `"ethersync/ethersync-nvim"` to your plugin man
   keys = { 
     { "<leader>ej", "<cmd>EthersyncJumpToCursor<cr>" },
     { "<leader>ef", "<cmd>EthersyncFollow<cr>" },
-    { "<esc>", mode = { "n" }, "<cmd>EthersyncUnfollow<cr>" },
   },
   lazy = false,
 }
@@ -52,7 +51,6 @@ Usually, you will add the string `"ethersync/ethersync-nvim"` to your plugin man
   config = function()
     vim.keymap.set('n', '<leader>ej', '<cmd>EthersyncJumpToCursor<cr>')
     vim.keymap.set('n', '<leader>ef', '<cmd>EthersyncFollow<cr>')
-    vim.keymap.set('n', '<esc>', '<cmd>EthersyncUnfollow<cr>')
   end
 }
 ```
@@ -71,7 +69,7 @@ To confirm that the plugin is installed, try running the `:EthersyncInfo` comman
 
 ## Tips
 
-We recommend creating mappings for the `:EthersyncJumpToCursor`, `:EthersyncFollow` and `EthersyncUnfollow` command, see above configurations for examples.
+We recommend creating mappings for the `:EthersyncJumpToCursor` and `:EthersyncFollow` command, see above configurations for examples.
 
 ## Configuration
 

--- a/nvim-plugin/doc/ethersync.txt
+++ b/nvim-plugin/doc/ethersync.txt
@@ -94,8 +94,6 @@ USAGE                                                          *ethersync-usage*
 :EthersyncFollow                                              *:EthersyncFollow*
     Follows another peer, keeping their cursor in view. If multiple cursors
     are present, gives you a selection menu.
-
-:EthersyncUnfollow                                          *:EthersyncUnfollow*
-    Stops following another peer.
+    It will automatically unfollow as soon as a key is pressed.
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/nvim-plugin/lua/ethersync.lua
+++ b/nvim-plugin/lua/ethersync.lua
@@ -262,7 +262,6 @@ local function activate_plugin()
     vim.api.nvim_create_user_command("EthersyncInfo", print_info, {})
     vim.api.nvim_create_user_command("EthersyncJumpToCursor", cursor.jump_to_cursor, {})
     vim.api.nvim_create_user_command("EthersyncFollow", cursor.follow_cursor, {})
-    vim.api.nvim_create_user_command("EthersyncUnfollow", cursor.unfollow_cursor, {})
 end
 
 activate_plugin()


### PR DESCRIPTION
fixes #420 

I did not remove the EthersyncUnfollow (but I can if you want to), I thought we could keep it in case I missed something and we ended up in an un-unfollowable condition, but, as far as I tested, it does not happen.
