### PR TITLE
nvim: Implement an teamtype.status() function for status bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # 0.9.2 (unreleased)
 
+Add status widget to the Neovim plugin with basic information to be used in statuslines.
+
 Fix issue blocking directories with deep nesting (or very long winded names) from being shared.
 
 Handle POSIX specific process signalling without assuming everybody is running a Unix platform.

--- a/nvim-plugin/README.md
+++ b/nvim-plugin/README.md
@@ -62,7 +62,8 @@ It should show the message "Not connected to Teamtype daemon."
 
 ## Tips
 
-We recommend creating mappings for the `:TeamtypeJumpToCursor` and `:TeamtypeFollow` command, see above configurations for examples.
+- Create mappings for the `:TeamtypeJumpToCursor` and `:TeamtypeFollow` command, see above configurations for examples.
+- Add the output of `require("teamtype").status()` to your status bar, see the [help file](doc/teamtype.txt) for an example.
 
 ## Configuration
 

--- a/nvim-plugin/doc/teamtype.txt
+++ b/nvim-plugin/doc/teamtype.txt
@@ -102,4 +102,27 @@ USAGE                                                           *teamtype-usage*
     are present, gives you a selection menu.
     It will automatically unfollow as soon as a key is pressed.
 
+==============================================================================
+STATUS LINE                                               *teamtype-status-line*
+
+Teamtype exposes a `require("teamtype").status()` function, which displays a
+brief summary of connection status and where other people are editing. You can
+add this to your status line by, for example, using a plugin like lualine and
+a lualine configuration snippet like this:
+>lua
+  sections = {
+    lualine_c = {
+        {
+            function()
+                return require("teamtype").status()
+            end,
+        },
+    },
+  }
+
+Lua functions can also be reached using Vim's status line escape codes if your
+status line is configured that way, e.g. to replace the whole status line:
+
+  :set statusline=%!v:lua.require('teamtype').status()
+<
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/nvim-plugin/lua/teamtype.lua
+++ b/nvim-plugin/lua/teamtype.lua
@@ -141,6 +141,16 @@ local function find_or_create_client(config_name, root_dir)
     }
     local the_connection = connection.connect(configurations[config_name].cfg.cmd, root_dir, function(m, p)
         process_operation_for_editor(client, m, p)
+    end,
+    function()
+        -- React to disconnect.
+        for _, c in ipairs(clients) do
+            if c == client then
+                for _, buf_nr in ipairs(c.buffers) do
+                    vim.bo[buf_nr].modifiable = false
+                end
+            end
+        end
     end)
     client.connection = the_connection
     table.insert(clients, client)

--- a/nvim-plugin/lua/teamtype.lua
+++ b/nvim-plugin/lua/teamtype.lua
@@ -141,14 +141,22 @@ local function find_or_create_client(config_name, root_dir)
     }
     local the_connection = connection.connect(configurations[config_name].cfg.cmd, root_dir, function(m, p)
         process_operation_for_editor(client, m, p)
-    end,
-    function()
+    end, function()
         -- React to disconnect.
-        for _, c in ipairs(clients) do
+        local to_remove = {}
+        for i, c in ipairs(clients) do
             if c == client then
                 for _, buf_nr in ipairs(c.buffers) do
                     vim.bo[buf_nr].modifiable = false
                 end
+            end
+            to_remove[i] = true
+        end
+
+        -- Remove from clients list.
+        for i = #clients, 1, -1 do
+            if to_remove[i] then
+                table.remove(clients, i)
             end
         end
     end)

--- a/nvim-plugin/lua/teamtype.lua
+++ b/nvim-plugin/lua/teamtype.lua
@@ -171,7 +171,6 @@ local function find_or_create_client(config_name, root_dir)
                     vim.api.nvim_err_writeln(
                         "Connection to Teamtype daemon lost. Probably it crashed or was stopped. Please restart the daemon, then Neovim."
                     )
-                    -- TODO: Enable writing here again, so that user can make backup of file?
                 end)
             else
                 print(
@@ -186,11 +185,18 @@ local function find_or_create_client(config_name, root_dir)
                 local to_remove = {}
                 for i, c in ipairs(clients) do
                     if c == client then
-                        for _, buf_nr in ipairs(c.buffers) do
-                            vim.bo[buf_nr].modifiable = false
+                        to_remove[i] = true
+
+                        -- If the daemon crashed, prevent modifications to the buffers to save users from
+                        -- accidental data losss.
+                        if code == 0 then
+                            for _, buf_nr in ipairs(c.buffers) do
+                                vim.bo[buf_nr].modifiable = false
+
+                                -- TODO: Enable writing here again, so that user can make backup of file?
+                            end
                         end
                     end
-                    to_remove[i] = true
                 end
 
                 -- Remove from clients list.

--- a/nvim-plugin/lua/teamtype.lua
+++ b/nvim-plugin/lua/teamtype.lua
@@ -156,27 +156,54 @@ local function find_or_create_client(config_name, root_dir)
         buffers = {},
         connection = nil,
     }
-    local the_connection = connection.connect(configurations[config_name].cfg.cmd, root_dir, function(m, p)
-        process_operation_for_editor(client, m, p)
-    end, function()
-        -- React to disconnect.
-        local to_remove = {}
-        for i, c in ipairs(clients) do
-            if c == client then
-                for _, buf_nr in ipairs(c.buffers) do
-                    vim.bo[buf_nr].modifiable = false
-                end
-            end
-            to_remove[i] = true
-        end
 
-        -- Remove from clients list.
-        for i = #clients, 1, -1 do
-            if to_remove[i] then
-                table.remove(clients, i)
+    -- TODO: Encapsulate these dispatchers in the connection module better?
+    local dispatchers = {
+        notification = function(m, p)
+            process_operation_for_editor(client, m, p)
+        end,
+        on_error = function(code, ...)
+            print("Teamtype connection error: ", code, vim.inspect({ ... }))
+        end,
+        on_exit = function(code, _)
+            if code == 0 then
+                vim.schedule(function()
+                    vim.api.nvim_err_writeln(
+                        "Connection to Teamtype daemon lost. Probably it crashed or was stopped. Please restart the daemon, then Neovim."
+                    )
+                    -- TODO: Enable writing here again, so that user can make backup of file?
+                end)
+            else
+                print(
+                    "Could not connect to Teamtype daemon. Did you start it (in "
+                        .. root_dir
+                        .. ")? To stop trying, remove the .teamtype/ directory."
+                )
             end
-        end
-    end)
+
+            vim.schedule(function()
+                -- React to disconnect.
+                local to_remove = {}
+                for i, c in ipairs(clients) do
+                    if c == client then
+                        for _, buf_nr in ipairs(c.buffers) do
+                            vim.bo[buf_nr].modifiable = false
+                        end
+                    end
+                    to_remove[i] = true
+                end
+
+                -- Remove from clients list.
+                for i = #clients, 1, -1 do
+                    if to_remove[i] then
+                        table.remove(clients, i)
+                    end
+                end
+            end)
+        end,
+    }
+
+    local the_connection = connection.connect(configurations[config_name].cfg.cmd, root_dir, dispatchers)
     client.connection = the_connection
     table.insert(clients, client)
 

--- a/nvim-plugin/lua/teamtype.lua
+++ b/nvim-plugin/lua/teamtype.lua
@@ -45,6 +45,23 @@ function M.enable(name, enable)
     configurations[name].enabled = enable
 end
 
+function M.status()
+    if #clients == 0 then
+        return ""
+    end
+
+    local result = "Teamtype: "
+
+    local n = cursor.number_of_cursors()
+    if n > 0 then
+        result = result .. cursor.short_cursor_description()
+    else
+        result = result .. "active"
+    end
+
+    return result
+end
+
 -- Take an operation from the daemon and apply it to the editor.
 local function process_operation_for_editor(client, method, parameters)
     if method == "edit" then

--- a/nvim-plugin/lua/teamtype/connection.lua
+++ b/nvim-plugin/lua/teamtype/connection.lua
@@ -36,7 +36,7 @@ function Connection:send_request(method, params, result_callback, err_callback)
 end
 
 -- Connect to the daemon, and return a handle on the connection.
-function M.connect(cmd, directory, on_notification)
+function M.connect(cmd, directory, on_notification, on_disconnect)
     local executable = cmd[1]
     if vim.fn.executable(executable) == 0 then
         vim.api.nvim_err_writeln(
@@ -58,6 +58,7 @@ function M.connect(cmd, directory, on_notification)
                     vim.api.nvim_err_writeln(
                         "Connection to Teamtype daemon lost. Probably it crashed or was stopped. Please restart the daemon, then Neovim."
                     )
+                    on_disconnect()
                     -- TODO: Enable writing here again, so that user can make backup of file?
                 end)
             else

--- a/nvim-plugin/lua/teamtype/connection.lua
+++ b/nvim-plugin/lua/teamtype/connection.lua
@@ -36,7 +36,7 @@ function Connection:send_request(method, params, result_callback, err_callback)
 end
 
 -- Connect to the daemon, and return a handle on the connection.
-function M.connect(cmd, directory, on_notification, on_disconnect)
+function M.connect(cmd, directory, dispatchers)
     local executable = cmd[1]
     if vim.fn.executable(executable) == 0 then
         vim.api.nvim_err_writeln(
@@ -46,33 +46,6 @@ function M.connect(cmd, directory, on_notification, on_disconnect)
         )
         return nil
     end
-
-    local dispatchers = {
-        notification = on_notification,
-        on_error = function(code, ...)
-            print("Teamtype connection error: ", code, vim.inspect({ ... }))
-        end,
-        on_exit = function(code, _)
-            if code == 0 then
-                vim.schedule(function()
-                    vim.api.nvim_err_writeln(
-                        "Connection to Teamtype daemon lost. Probably it crashed or was stopped. Please restart the daemon, then Neovim."
-                    )
-                    on_disconnect()
-                    -- TODO: Enable writing here again, so that user can make backup of file?
-                end)
-            else
-                print(
-                    "Could not connect to Teamtype daemon. Did you start it (in "
-                        .. directory
-                        .. ")? To stop trying, remove the .teamtype/ directory."
-                )
-                vim.schedule(function()
-                    on_disconnect()
-                end)
-            end
-        end,
-    }
 
     local connection
     local extra_spawn_params = { cwd = directory }

--- a/nvim-plugin/lua/teamtype/connection.lua
+++ b/nvim-plugin/lua/teamtype/connection.lua
@@ -67,6 +67,9 @@ function M.connect(cmd, directory, on_notification, on_disconnect)
                         .. directory
                         .. ")? To stop trying, remove the .teamtype/ directory."
                 )
+                vim.schedule(function()
+                    on_disconnect()
+                end)
             end
         end,
     }

--- a/nvim-plugin/lua/teamtype/cursor.lua
+++ b/nvim-plugin/lua/teamtype/cursor.lua
@@ -357,6 +357,26 @@ function M.jump_to_cursor()
     pick_cursor_menu(callback)
 end
 
+function M.number_of_cursors()
+    local count = 0
+    for _, v in pairs(user_cursors) do
+        if #v.cursors > 0 then
+            count = count + 1
+        end
+    end
+    return count
+end
+
+function M.short_cursor_description()
+    local users = {}
+    for _, data in pairs(user_cursors) do
+        if #data.cursors > 0 then
+            table.insert(users, data.name)
+        end
+    end
+    return table.concat(users, ", ")
+end
+
 function M.list_cursors()
     local message = ""
 

--- a/nvim-plugin/lua/teamtype/cursor.lua
+++ b/nvim-plugin/lua/teamtype/cursor.lua
@@ -367,14 +367,36 @@ function M.number_of_cursors()
     return count
 end
 
+-- Returns a description of remote cursors that are known to us.
 function M.short_cursor_description()
     local users = {}
+
+    -- Build a structure using the values as keys, so they are de-duplicated.
     for _, data in pairs(user_cursors) do
         if #data.cursors > 0 then
-            table.insert(users, data.name)
+            if not users[data.name] then
+                users[data.name] = {}
+            end
+            for _, c in ipairs(data.cursors) do
+                users[data.name][vim.fs.basename(c.uri)] = true
+            end
         end
     end
-    return table.concat(users, ", ")
+
+    -- Now, build a string that we can return.
+    local user_list = {}
+
+    for name, files in pairs(users) do
+        local file_list = {}
+
+        for file, _ in pairs(files) do
+            table.insert(file_list, file)
+        end
+
+        table.insert(user_list, name .. " (" .. table.concat(file_list, ", ") .. ")")
+    end
+
+    return table.concat(user_list, ", ")
 end
 
 function M.list_cursors()


### PR DESCRIPTION
This is supposed to show a short status like "Teamtyping with <name> and <name>" in a status bar plugin of your choice.

## Missing things

- [x] Actually check whether the client is still online (should also be added to `:TeamtypeInfo`)
- [x] Don't repeat user names if they have multiple files open
- [x] Maybe mention in which files people are?
- [x] Document

## How to try

This can be used with a lualine config like this (feel free to add the teamtype part in whichever section you want):

```lua
return {
    "nvim-lualine/lualine.nvim",
    dependencies = {
        {
            "nvim-tree/nvim-web-devicons",
        },
    },
    opts = {
        sections = {
            lualine_a = { "mode" },
            lualine_b = { "filename" },
            lualine_c = {
                {
                    function()
                        return require("teamtype").status()
                    end,
                },
            },
            lualine_x = {},
            lualine_y = { "location" },
            lualine_z = { "progress" },
        },
    },
}
```