### PR TITLE
Fix race condition where we may receive edit requests before initializing document state

### DIFF
--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -354,15 +354,17 @@ function activateConfigForTextDocument(name: string, document: vscode.TextDocume
     const uri = document.uri.toString()
     debug("OPEN " + decodeURI(uri))
     const content = document.getText()
+
+    // Initialize before sending the open request to make sure
+    // we can immediately handle potential edits
+    client.ot_states[uri] = {
+        revision: new Revision(),
+        content: getLines(document),
+    };
+
     client.connection
         .sendRequest(openType, {uri, content})
         .then(() => {
-            client.ot_states[uri] = {
-                revision: new Revision(),
-                content: getLines(document),
-            }
-
-            updateContents(client, document)
             debug("Successfully opened. Tracking changes.")
         })
         .catch(() => {


### PR DESCRIPTION
Depending on daemon timings, it is possible to receive an edit notification right after sending an open request, before the document state is initialized. The result is an "undefined is not an object" type of error when accessing client.ot_states[uri].

Seen with an alternative server (not the Teamtype daemon) which likely behaves slightly different wrt timing. I don't have the development setup anymore to check, but I *think* that it sent the response to the open message before the edit notification.

EDIT I think the server was buggy and didn't send a response for the open :)