### PR TITLE
daemon: Push minimum Rust version to 1.89

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -22,7 +22,7 @@ keywords = [
 ]
 categories = ["command-line-utilities", "text-editors"]
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.89.0"
 default-run = "teamtype"
 
 [lib]


### PR DESCRIPTION
We need to push our version to `1.89`:

When I [upgraded the packages](https://github.com/teamtype/teamtype/pull/476), I first updated the rust compiler to version `1.91`, then did all the version upgrades. In the PR review we discussed, that we rather might [want to use `cargo msrv`](https://github.com/teamtype/teamtype/pull/476#discussion_r2754341207) to determine it, which made me retrospectively use `1.85` and then rebase all the other changes on top of it.

Apparently I ran `cargo msrv` at the wrong time. Running it on 768ee74e I get:

```bash
 cargo msrv find
  [Meta]   cargo-msrv 0.18.4

Compatibility Check #1: Rust 1.89.0
  [OK]     Is compatible

Compatibility Check #2: Rust 1.87.0
  [FAIL]   Is incompatible

  ╭────────────────────────────────────────────────────────────────────────╮
  │ error: rustc 1.87.0 is not supported by the following packages:        │
  │   automerge@0.7.3 requires rustc 1.89.0                                │
[...]
  │   time@0.3.46 requires rustc 1.88.0                                    │
  │   time-core@0.1.8 requires rustc 1.88.0                                │
  │   time-core@0.1.8 requires rustc 1.88.0                                │
  │   time-macros@0.2.26 requires rustc 1.88.0                             │
  │ Either upgrade rustc or select compatible dependency versions with     │
  │ `cargo update <name>@<current-ver> --precise <compatible-ver>`         │
  │ where `<compatible-ver>` is the latest version supporting rustc 1.87.0 │
  │                                                                        │
  │                                                                        │
  ╰────────────────────────────────────────────────────────────────────────╯


Compatibility Check #3: Rust 1.88.0
  [FAIL]   Is incompatible

[...]


Result:
   Considered (min … max):   Rust 1.85.1 … Rust 1.93.0
   Search method:            bisect
   MSRV:                     1.89.0
   Target:                   x86_64-apple-darwin
```

[See also Zulip](https://teamtype.zulipchat.com/#narrow/channel/562985-daemon/topic/broken.20.60main.60.3A.20minimum.20Rust.20version.20confusion/near/571884300)