### PR TITLE
Cache file contents in Document, to avoid costly calls to Automerge::text()

### DIFF
--- a/daemon/integration-tests/src/actors.rs
+++ b/daemon/integration-tests/src/actors.rs
@@ -6,7 +6,7 @@
 use crate::socket::*;
 
 use teamtype::daemon::Daemon;
-use teamtype::sandbox;
+use teamtype::{document, sandbox};
 
 use async_trait::async_trait;
 pub use nvim_rs::{compat::tokio::Compat, create::tokio::new_child_cmd, rpc::handler::Dummy};
@@ -75,7 +75,10 @@ impl Actor for Daemon {
     }
 
     async fn content(&self) -> String {
-        self.document_handle.content().await.unwrap()
+        let Some(document::Content::String(string)) = self.document_handle.content().await else {
+            panic!("Could not retrive a string via .content()");
+        };
+        string
     }
 }
 

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -481,7 +481,8 @@ impl DocumentActor {
             // TODO: Once we get back to processing file changes while editors have it
             // open, send the delta returned by update_text to editors.
         } else {
-            self.crdt_doc.set_bytes(&new_content, relative_file_path);
+            self.crdt_doc
+                .set_file(document::Content::Bytes(new_content), relative_file_path);
         }
         let _ = self.doc_changed_ping_tx.send(());
     }
@@ -613,12 +614,16 @@ impl DocumentActor {
                     if self.owns(&relative_file_path) {
                         if let Ok(text) = String::from_utf8(bytes.clone()) {
                             if init {
-                                self.crdt_doc.initialize_text(&text, &relative_file_path);
+                                self.crdt_doc.set_file(
+                                    document::Content::String(text.clone()),
+                                    &relative_file_path,
+                                );
                             } else {
                                 self.crdt_doc.update_text(&text, &relative_file_path);
                             }
                         } else {
-                            self.crdt_doc.set_bytes(&bytes, &relative_file_path);
+                            self.crdt_doc
+                                .set_file(document::Content::Bytes(bytes), &relative_file_path);
                         }
                     }
                 }
@@ -695,7 +700,8 @@ impl DocumentActor {
                     }
                 } else {
                     // The file doesn't exist yet - create it in the Automerge document.
-                    self.crdt_doc.initialize_text(content, file_path);
+                    self.crdt_doc
+                        .set_file(document::Content::String(content.clone()), file_path);
                     let _ = self.doc_changed_ping_tx.send(());
                     self.write_file(file_path);
                 }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -227,7 +227,7 @@ impl DocumentActor {
 
                 let patches = self.apply_sync_message_to_doc(message, &mut peer_state);
 
-                let patch_effects = PatchEffect::from_crdt_patches(patches);
+                let patch_effects = PatchEffect::from_crdt_patches(&patches);
 
                 let mut file_deltas = vec![];
 

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -430,18 +430,6 @@ impl Document {
     }
 
     #[must_use]
-    pub fn files_at(&self, heads: &[ChangeHash]) -> Vec<RelativePath> {
-        self.top_level_map_obj("files")
-            .map(|file_map| {
-                self.doc
-                    .keys_at(file_map, heads)
-                    .map(|k| RelativePath::new(&k))
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
-
-    #[must_use]
     pub fn file_exists(&self, file_path: &RelativePath) -> bool {
         self.files.contains_key(file_path)
     }

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -3,9 +3,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::collections::HashMap;
+
 use crate::{
     path::RelativePath,
-    types::{EditorTextDelta, TextDelta},
+    types::{EditorTextDelta, PatchEffect, TextDelta},
 };
 use anyhow::{Result, bail};
 use automerge::{
@@ -15,6 +17,12 @@ use automerge::{
 };
 use dissimilar::Chunk;
 use tracing::{debug, info};
+
+#[derive(Debug)]
+pub enum Content {
+    String(String),
+    Bytes(Vec<u8>),
+}
 
 /// Encapsulates the Automerge `AutoCommit` and provides a generic interface,
 /// s.t. we don't need to worry about automerge internals elsewhere.
@@ -27,6 +35,7 @@ use tracing::{debug, info};
 #[derive(Debug)]
 #[must_use]
 pub struct Document {
+    files: HashMap<RelativePath, Content>,
     doc: AutoCommit,
 }
 
@@ -52,7 +61,12 @@ impl Document {
     pub fn load(bytes: &[u8]) -> Self {
         let doc =
             AutoCommit::load(bytes).expect("Failed to load Automerge document from given bytes");
-        Self { doc }
+        let mut result = Self {
+            files: HashMap::default(),
+            doc,
+        };
+        result.update_files();
+        result
     }
 
     #[must_use]
@@ -81,7 +95,43 @@ impl Document {
             .sync()
             .receive_sync_message_log_patches(peer_state, message, &mut patch_log)
             .expect("Failed to apply sync message to Automerge document");
-        self.doc.make_patches(&mut patch_log)
+        let patches = self.doc.make_patches(&mut patch_log);
+
+        // Update files cache.
+        for patch in &patches {
+            match PatchEffect::try_from(patch).expect("Should be able to convert to patch effect") {
+                PatchEffect::FileChange(file_text_delta) => {
+                    let old_text = if let Some(Content::String(old_text)) =
+                        self.files.get(&file_text_delta.file_path)
+                    {
+                        old_text
+                    } else {
+                        // File does not exist yet, create an empty one.
+                        self.files.insert(
+                            file_text_delta.file_path.clone(),
+                            Content::String(String::new()),
+                        );
+                        ""
+                    };
+                    // We're not in a good position here to "reject" the sync message, so let's
+                    // panic on errors.
+                    let new_text = file_text_delta.delta.apply_to(old_text).expect("If Automerge and our file cache work correctly, this delta should always apply");
+                    self.files
+                        .insert(file_text_delta.file_path, Content::String(new_text));
+                }
+                PatchEffect::FileRemoval(path) => {
+                    self.files.remove(&path);
+                }
+                PatchEffect::FileBytes(path, bytes) => {
+                    self.files.insert(path, Content::Bytes(bytes));
+                }
+                PatchEffect::NoEffect => {
+                    // Nothing to do.
+                }
+            }
+        }
+
+        patches
     }
 
     #[must_use]
@@ -97,6 +147,7 @@ impl Document {
         delta: &TextDelta,
         file_path: &RelativePath,
     ) -> Result<()> {
+        // Update Automerge document.
         let text_obj = self
             .text_obj(file_path)
             .expect("Couldn't get automerge text object, so not able to modify it");
@@ -121,15 +172,23 @@ impl Document {
             offset -= length as isize;
             offset += op.replacement.chars().count() as isize;
         }
+
+        // Update cached content.
+        let Some(Content::String(old_text)) = self.files.get(file_path) else {
+            panic!("Did not find text content in files cache at file_path");
+        };
+        let new_text = delta.apply_to(old_text)?;
+        self.files
+            .insert(file_path.clone(), Content::String(new_text));
+
         Ok(())
     }
 
     pub fn current_file_content(&self, file_path: &RelativePath) -> Result<String> {
-        self.text_obj(file_path).map(|to| {
-            self.doc
-                .text(to)
-                .expect("Failed to get string from Automerge text object")
-        })
+        let Some(Content::String(text)) = self.files.get(file_path) else {
+            bail!("No string content at {file_path}")
+        };
+        Ok(text.clone())
     }
 
     // TODO: Refactor such that file_content_at can also return bytes (and get rid of get_bytes_at)
@@ -145,10 +204,14 @@ impl Document {
         })
     }
 
+    // TODO: Get rid of this.
     /// Used to get the contents of a binary file.
-    pub fn get_bytes(&mut self, file_path: &RelativePath) -> Result<Vec<u8>> {
-        let heads = self.get_heads();
-        self.get_bytes_at(file_path, &heads)
+    pub fn get_bytes(&self, file_path: &RelativePath) -> Result<Vec<u8>> {
+        let Some(Content::Bytes(bytes)) = self.files.get(file_path) else {
+            bail!("No byte content at {file_path}")
+        };
+
+        Ok(bytes.clone())
     }
 
     /// Used to get the contents of a binary file at a specific state.
@@ -183,6 +246,8 @@ impl Document {
 
     pub fn initialize_text(&mut self, text: &str, file_path: &RelativePath) {
         info!("Initializing {file_path} in the Teamtype history.");
+        self.files
+            .insert(file_path.clone(), Content::String(String::from(text)));
 
         // Now it should definitely work?
         let file_map = self
@@ -219,6 +284,12 @@ impl Document {
             info!("Detected change of {file_path}. Updating.");
             debug!("Full delta of this update: {text_delta}");
             self.apply_delta_to_doc(&text_delta, file_path).expect("Failed to apply delta to document while updating text. Probably the delta doesn't fit the document content.");
+
+            self.files.insert(
+                file_path.clone(),
+                Content::String(String::from(desired_text)),
+            );
+
             Some(text_delta)
         } else {
             // The file doesn't exist in the CRDT yet, so we need to initialize it.
@@ -235,26 +306,31 @@ impl Document {
 
         info!("Removing {file_path} from the Teamtype history.");
 
+        // Remove from Automerge document.
         let file_map = self
             .top_level_map_obj("files")
             .expect("Failed to get files Map object");
         self.doc
             .delete(file_map, file_path)
             .expect("Failed to delete text object");
+
+        // Remove from files cache.
+        self.files.remove(file_path);
     }
 
     /// Used to set or update a binary file's content.
     pub fn set_bytes(&mut self, bytes: &[u8], file_path: &RelativePath) {
-        let file_map = self
-            .top_level_map_obj("files")
-            .expect("Failed to get files Map object");
-
         // If the content hasn't changed, don't write to the file. This prevents irrelevant watcher events.
         if let Ok(current_bytes) = self.get_bytes(file_path)
             && current_bytes == bytes
         {
             return;
         }
+
+        // Update Automerge document.
+        let file_map = self
+            .top_level_map_obj("files")
+            .expect("Failed to get files Map object");
 
         // If the file was not in the document before, log this.
         if !self.file_exists(file_path) {
@@ -264,6 +340,49 @@ impl Document {
         self.doc
             .put(file_map, file_path, bytes.to_vec())
             .expect("Failed to initialize bytes object in Automerge document");
+
+        // Update file cache.
+        self.files
+            .insert(file_path.clone(), Content::Bytes(bytes.to_vec()));
+    }
+
+    fn update_files(&mut self) {
+        if let Ok(file_map) = self.top_level_map_obj("files") {
+            for file_path in self.doc.keys(&file_map) {
+                match self.doc.get(&file_map, &file_path) {
+                    Ok(Some((automerge::Value::Object(ObjType::Text), text_obj))) => {
+                        let string = self
+                            .doc
+                            .text(&text_obj)
+                            .expect("Should be able to retreive text");
+                        self.files
+                            .insert(RelativePath::new(&file_path), Content::String(string));
+                    }
+                    Ok(Some((
+                        automerge::Value::Scalar(std::borrow::Cow::Owned(
+                            automerge::ScalarValue::Bytes(bytes),
+                        )),
+                        _,
+                    ))) => {
+                        self.files
+                            .insert(RelativePath::new(&file_path), Content::Bytes(bytes));
+                    }
+                    Ok(Some((
+                        automerge::Value::Scalar(std::borrow::Cow::Borrowed(
+                            automerge::ScalarValue::Bytes(bytes),
+                        )),
+                        _,
+                    ))) => {
+                        // TODO: Potentially memory-heavy operation. Figure out how to deal with Cows. Moo.
+                        self.files
+                            .insert(RelativePath::new(&file_path), Content::Bytes(bytes.clone()));
+                    }
+                    _ => {
+                        panic!("Found unexpected object while iterating over Automerge document");
+                    }
+                }
+            }
+        }
     }
 
     fn top_level_map_obj(&self, name: &str) -> Result<automerge::ObjId> {
@@ -315,14 +434,7 @@ impl Document {
 
     #[must_use]
     pub fn files(&self) -> Vec<RelativePath> {
-        self.top_level_map_obj("files")
-            .map(|file_map| {
-                self.doc
-                    .keys(file_map)
-                    .map(|k| RelativePath::new(&k))
-                    .collect()
-            })
-            .unwrap_or_default()
+        self.files.keys().map(Clone::clone).collect()
     }
 
     #[must_use]
@@ -339,12 +451,7 @@ impl Document {
 
     #[must_use]
     pub fn file_exists(&self, file_path: &RelativePath) -> bool {
-        self.top_level_map_obj("files").is_ok_and(|file_map| {
-            self.doc
-                .get(file_map, file_path)
-                .unwrap_or_else(|_| panic!("Failed to get {file_path} key from Automerge document"))
-                .is_some()
-        })
+        self.files.contains_key(file_path)
     }
 
     #[must_use]

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -170,7 +170,7 @@ pub enum PatchEffect {
 }
 
 impl PatchEffect {
-    pub fn from_crdt_patches(patches: Vec<Patch>) -> Vec<Self> {
+    pub fn from_crdt_patches(patches: &[Patch]) -> Vec<Self> {
         let mut file_deltas: Vec<Self> = vec![];
 
         for patch in patches {
@@ -331,10 +331,10 @@ impl TextDelta {
 
 // TODO: This feels like it should go into another file, close to where Document handles writing to
 // the Automerge document. Both places need to know about our chosen structure.
-impl TryFrom<Patch> for PatchEffect {
+impl TryFrom<&Patch> for PatchEffect {
     type Error = anyhow::Error;
 
-    fn try_from(patch: Patch) -> Result<Self, Self::Error> {
+    fn try_from(patch: &Patch) -> Result<Self, Self::Error> {
         fn file_path_from_path_default(
             path: &[(automerge::ObjId, automerge::Prop)],
         ) -> Result<RelativePath, anyhow::Error> {
@@ -353,7 +353,7 @@ impl TryFrom<Patch> for PatchEffect {
         }
 
         if patch.path.is_empty() {
-            return match patch.action {
+            return match &patch.action {
                 PatchAction::PutMap { key, .. } => {
                     if key == "files" {
                         Ok(Self::NoEffect)
@@ -372,7 +372,7 @@ impl TryFrom<Patch> for PatchEffect {
         match &patch.path[0] {
             (_, automerge::Prop::Map(key)) if key == "files" => {
                 if patch.path.len() == 1 {
-                    match patch.action {
+                    match &patch.action {
                         PatchAction::PutMap {
                             key,
                             conflict,
@@ -380,11 +380,11 @@ impl TryFrom<Patch> for PatchEffect {
                         } => {
                             // This action happens when a new file is created.
 
-                            let relative_path = RelativePath::new(&key);
+                            let relative_path = RelativePath::new(key);
 
                             match value {
                                 (automerge::Value::Object(automerge::ObjType::Text), _) => {
-                                    if conflict {
+                                    if *conflict {
                                         // In this case, the peer receiving this PutMap should
                                         // remove all existing content of this file in open
                                         // editors. So we emit a FileRemovel.
@@ -406,7 +406,7 @@ impl TryFrom<Patch> for PatchEffect {
                                         automerge::ScalarValue::Bytes(bytes),
                                     )),
                                     _,
-                                ) => Ok(Self::FileBytes(relative_path, bytes)),
+                                ) => Ok(Self::FileBytes(relative_path, bytes.clone())),
                                 _ => {
                                     Err(anyhow::anyhow!("Unexpected value in path {relative_path}"))
                                 }
@@ -415,7 +415,7 @@ impl TryFrom<Patch> for PatchEffect {
                         PatchAction::DeleteMap { key } => {
                             // This action happens when a file is deleted.
                             debug!("Got file removal from patch: {key}");
-                            Ok(Self::FileRemoval(RelativePath::new(&key)))
+                            Ok(Self::FileRemoval(RelativePath::new(key)))
                         }
                         PatchAction::Conflict { prop } => {
                             // This can happen when both sides create the same file.
@@ -439,9 +439,9 @@ impl TryFrom<Patch> for PatchEffect {
                     }
                 } else if patch.path.len() == 2 {
                     let mut delta = TextDelta::default();
-                    match patch.action {
+                    match &patch.action {
                         PatchAction::SpliceText { index, value, .. } => {
-                            delta.retain(index);
+                            delta.retain(*index);
                             delta.insert(&value.make_string());
                             Ok(Self::FileChange(FileTextDelta::new(
                                 file_path_from_path_default(&patch.path)?,
@@ -449,8 +449,8 @@ impl TryFrom<Patch> for PatchEffect {
                             )))
                         }
                         PatchAction::DeleteSeq { index, length } => {
-                            delta.retain(index);
-                            delta.delete(length);
+                            delta.retain(*index);
+                            delta.delete(*length);
                             Ok(Self::FileChange(FileTextDelta::new(
                                 file_path_from_path_default(&patch.path)?,
                                 delta,


### PR DESCRIPTION
I used [samply](https://github.com/mstange/samply) to profile a large document with ~160 files and many thousand individual edits. I was especially interested in the performance of regular usage, that means after making a connection, just typing some letters and syncing them to a single peer.

## The culprit

I noticed that ~70% of the time was spent in `Automerge::text_for`, see the "Before" screenshot. This surprised me! I thought getting the current content of a text document from Automerge would be a cheap operation, but I guess [humans are terrible at guessing about performance](https://github.com/flamegraph-rs/flamegraph#humans-are-terrible-at-guessing-about-performance)…

`text_for` was called during `RescanFiles` events, to compare the current directory content to the "true" CRDT content. We trigger the file watcher by writing the changed file ourselves; ideally this would be avoided in the future, as well.

## Solution

My fix was to introduce a "files cache" in Document, which holds the "true" content. All methods that change the Automerge document now change that cache, as well. And all methods that access the files try to use the cache, whenever possible.

Other commits in this PR do some refactorings related to the method signatures of several of the methods that are involved.

## Results

| Before | After |
| --- | --- |
| ![image-before](https://github.com/user-attachments/assets/5f686b09-589a-444a-bd4b-9e082856a525) | ![image-after](https://github.com/user-attachments/assets/541e4434-e399-47aa-a74e-cf1e914155c8)

Notice how the big block in the graph on the left that's about `text_for` is basically completely gone on the right.

On current main, I counted around 623 profiler samples per second. On this branch, I count around 121. So I'd estimate that Teamtype has to do around **5 times less "work"** in this case.

I also tried to measure the typing delay from a local peer, connected to a cloud peer, connected to my local device again (so @zormit, our typical wiki setup, with the real big document), but I have only anecdotal evidence:

- Typing a single letter arrived after around 250 ms on `main`, and around 140 ms on this branch.
- Typing a sentence in normal speed on `main` arrived with a significant delay – it took more than 10 seconds for a 60-character sentence to arrive in full after I stopped typing it. On this branch, there was a "total delay" of 3 seconds or so. Still not great, but better! :)

## Future work

We don't have much control over the performance of Automerge… I opened [an issue](https://github.com/automerge/automerge/issues/1042) to document my largest bottleneck there.

I think it would make sense to put the "content cache" in the center of the system, architecturally. (So that we could "swap out" the "remote component" more easily in the future.) I have some bigger refactorings in the pipeline for that, but it's not done, it's still messy, and I thought it would make sense to let you review this first step first.