### PR TITLE
nvim: ignore unnamed buffers

### DIFF
--- a/nvim-plugin/lua/teamtype.lua
+++ b/nvim-plugin/lua/teamtype.lua
@@ -183,6 +183,12 @@ local function on_buffer_open()
     local buf_nr = tonumber(vim.fn.expand("<abuf>"))
     local buf_name = vim.api.nvim_buf_get_name(buf_nr)
 
+    -- Early return to avoid unnamed buffers such as diagnostics
+    -- Resolves #491
+    if buf_name == "" then
+        return
+    end
+
     for name, server in pairs(configurations) do
         if server.enabled then
             if server.cfg.root_dir then


### PR DESCRIPTION
Ignores file buffers without name. Mainly targeted at ignoring diagnostics file in nvim, which doesn't need to be synced.

Not sure if this conflicts with other files with unnamed buffers. I'm open for suggestions

This resolves the issue I had in #491. However, when I debugged it I wasn't able to reproduce the same error but got the other one I mentioned with triple slashes "///" and error about not finding the diagnostics file.

Resolves #491