### PR TITLE
introduce the ability to specify an .teamtypeignore file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Add support for JSON-RPC IDs in string to be compliant with the [JSON-RPC specification](https://www.jsonrpc.org/specification).
 
+Add support for `.teamtypeignore` file to exclude files and directories from synchronization. The syntax is similar to `.gitignore`, supporting file names, directories, and glob patterns.
+
 ## Note for package maintainers: Renamed the Linux binaries
 
 We've renamed the Linux binaries

--- a/book/src/ignored-files.md
+++ b/book/src/ignored-files.md
@@ -10,7 +10,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 Teamtype ignores
 
 - `.teamtype` and everything in it,
+- all files ignored via `.teamtypeignore` files (which work like `.gitignore` files),
 - everything that Git would [ignore](https://git-scm.com/docs/gitignore), and
 - version control directories including `.git`, `.jj`, `.bzr`, `.hg`, `.pijul`, and even `.svn`, and everything in them by default. The `--sync-vcs` flag enables sharing these directories, see [here](git-integration-synchronized.md) for details.
 
-To prevent Teamtype from sharing files that contain sensitive information, like secrets, with your peers, add them to a `.gitignore` file.
+Note that you shouldn't rely on `.gitignore` or `.teamtypeignore` files to "protect sensitive information" from being shared with peers you don't trust, as the peers could easily delete these ignore files.

--- a/daemon/src/sandbox.rs
+++ b/daemon/src/sandbox.rs
@@ -248,6 +248,19 @@ mod tests {
         fs::write(project_dir.join("dir").join("b"), b"This is b file")
             .expect("Failed to write file");
         fs::write(dir.path().join("secret"), b"This is a secret").expect("Failed to write file");
+        fs::write(project_dir.join("a.txt"), b"visible file").expect("Failed to write file");
+        fs::write(project_dir.join("b.txt"), b"another visible file")
+            .expect("Failed to write file");
+        fs::write(project_dir.join("secret.txt"), b"should be ignored")
+            .expect("Failed to write file");
+        fs::create_dir(project_dir.join("ignored_dir")).expect("Failed to create directory");
+        fs::write(
+            project_dir.join("ignored_dir").join("c.txt"),
+            b"should be ignored",
+        )
+        .expect("Failed to write file");
+        fs::write(project_dir.join("debug.log"), b"should be ignored")
+            .expect("Failed to write file");
 
         dir
     }
@@ -346,21 +359,6 @@ mod tests {
     fn obeys_teamtypeignore() {
         let dir = temp_dir_setup();
         let project_dir = dir.path().join("project");
-
-        fs::write(project_dir.join("a.txt"), b"visible file").expect("Failed to write file");
-        fs::write(project_dir.join("b.txt"), b"another visible file")
-            .expect("Failed to write file");
-        fs::write(project_dir.join("secret.txt"), b"should be ignored")
-            .expect("Failed to write file");
-
-        fs::create_dir(project_dir.join("ignored_dir")).expect("Failed to create directory");
-        fs::write(
-            project_dir.join("ignored_dir").join("c.txt"),
-            b"should be ignored",
-        )
-        .expect("Failed to write file");
-        fs::write(project_dir.join("debug.log"), b"should be ignored")
-            .expect("Failed to write file");
 
         fs::write(
             project_dir.join(".teamtypeignore"),

--- a/daemon/src/sandbox.rs
+++ b/daemon/src/sandbox.rs
@@ -247,20 +247,11 @@ mod tests {
         fs::create_dir(project_dir.join("dir")).expect("Failed to create directory");
         fs::write(project_dir.join("dir").join("b"), b"This is b file")
             .expect("Failed to write file");
-        fs::write(dir.path().join("secret"), b"This is a secret").expect("Failed to write file");
-        fs::write(project_dir.join("a.txt"), b"visible file").expect("Failed to write file");
-        fs::write(project_dir.join("b.txt"), b"another visible file")
-            .expect("Failed to write file");
-        fs::write(project_dir.join("secret.txt"), b"should be ignored")
-            .expect("Failed to write file");
-        fs::create_dir(project_dir.join("ignored_dir")).expect("Failed to create directory");
         fs::write(
-            project_dir.join("ignored_dir").join("c.txt"),
-            b"should be ignored",
+            dir.path().join("file-outside-of-project"),
+            b"This is a file outside of project",
         )
         .expect("Failed to write file");
-        fs::write(project_dir.join("debug.log"), b"should be ignored")
-            .expect("Failed to write file");
 
         dir
     }
@@ -359,44 +350,29 @@ mod tests {
     fn obeys_teamtypeignore() {
         let dir = temp_dir_setup();
         let project_dir = dir.path().join("project");
+        let teamtypeignore = project_dir.join(".teamtypeignore");
 
-        fs::write(
-            project_dir.join(".teamtypeignore"),
-            b"secret.txt\nignored_dir/\n*.log\n",
-        )
-        .expect("Failed to write .teamtypeignore");
+        fs::write(&teamtypeignore, b"a\n").expect("Failed to write .teamtypeignore");
 
         let app_config = AppConfig {
-            base_dir: project_dir,
+            base_dir: project_dir.clone(),
             ..Default::default()
         };
 
-        let files = enumerate_non_ignored_files(&app_config);
-        let file_names: Vec<&str> = files
-            .iter()
-            .filter_map(|p| p.file_name())
-            .filter_map(|n| n.to_str())
-            .collect();
+        assert!(
+            ignored(&app_config, &project_dir.join("a")).unwrap(),
+            "a should be ignored"
+        );
+        assert!(
+            !ignored(&app_config, &project_dir.join("dir/b")).unwrap(),
+            "b should be not ignored"
+        );
+
+        fs::write(&teamtypeignore, b"a\ndir\n").expect("Failed to write .teamtypeignore");
 
         assert!(
-            file_names.contains(&"a.txt"),
-            "a.txt should be in the list of files"
-        );
-        assert!(
-            file_names.contains(&"b.txt"),
-            "b.txt should be in the list of files"
-        );
-        assert!(
-            !file_names.contains(&"secret.txt"),
-            "secret.txt should be ignored by .teamtypeignore"
-        );
-        assert!(
-            !file_names.contains(&"ignored_dir"),
-            "ignored_dir should be ignored by .teamtypeignore"
-        );
-        assert!(
-            !file_names.contains(&"debug.log"),
-            "debug.log should be ignored by .teamtypeignore"
+            ignored(&app_config, &project_dir.join("dir/b")).unwrap(),
+            "now b should be ignored"
         );
     }
 
@@ -406,7 +382,13 @@ mod tests {
         let project_dir = dir.path().join("project");
 
         // Not within the base dir.
-        assert!(read_file(&project_dir, &project_dir.join("..").join("secret")).is_err());
+        assert!(
+            read_file(
+                &project_dir,
+                &project_dir.join("..").join("file-outside-of-project")
+            )
+            .is_err()
+        );
 
         // It "starts" with the base dir, but it's not inside it.
         assert!(

--- a/daemon/src/sandbox.rs
+++ b/daemon/src/sandbox.rs
@@ -344,10 +344,9 @@ mod tests {
 
     #[test]
     fn obeys_teamtypeignore() {
-        // set up test scenario:
-        let dir = tempdir().expect("Failed to create temp directory");
+        let dir = temp_dir_setup();
         let project_dir = dir.path().join("project");
-        fs::create_dir(&project_dir).expect("Failed to create directory");
+
         fs::write(project_dir.join("a.txt"), b"visible file").expect("Failed to write file");
         fs::write(project_dir.join("b.txt"), b"another visible file")
             .expect("Failed to write file");
@@ -355,7 +354,6 @@ mod tests {
             .expect("Failed to write file");
 
         fs::create_dir(project_dir.join("ignored_dir")).expect("Failed to create directory");
-
         fs::write(
             project_dir.join("ignored_dir").join("c.txt"),
             b"should be ignored",
@@ -382,7 +380,6 @@ mod tests {
             .filter_map(|n| n.to_str())
             .collect();
 
-        // assertions:
         assert!(
             file_names.contains(&"a.txt"),
             "a.txt should be in the list of files"

--- a/daemon/src/sandbox.rs
+++ b/daemon/src/sandbox.rs
@@ -108,6 +108,7 @@ pub fn enumerate_non_ignored_files(app_config: &AppConfig) -> Vec<PathBuf> {
     }
 
     let walk = WalkBuilder::new(&app_config.base_dir)
+        .add_custom_ignore_filename(".teamtypeignore")
         .standard_filters(true)
         .hidden(false)
         .require_git(false)
@@ -339,6 +340,69 @@ mod tests {
 
         // File not exist.
         assert!(read_file(&project_dir, &project_dir.join("nonexistant")).is_err());
+    }
+
+    #[test]
+    fn obeys_teamtypeignore() {
+        // set up test scenario:
+        let dir = tempdir().expect("Failed to create temp directory");
+        let project_dir = dir.path().join("project");
+        fs::create_dir(&project_dir).expect("Failed to create directory");
+        fs::write(project_dir.join("a.txt"), b"visible file").expect("Failed to write file");
+        fs::write(project_dir.join("b.txt"), b"another visible file")
+            .expect("Failed to write file");
+        fs::write(project_dir.join("secret.txt"), b"should be ignored")
+            .expect("Failed to write file");
+
+        fs::create_dir(project_dir.join("ignored_dir")).expect("Failed to create directory");
+
+        fs::write(
+            project_dir.join("ignored_dir").join("c.txt"),
+            b"should be ignored",
+        )
+        .expect("Failed to write file");
+        fs::write(project_dir.join("debug.log"), b"should be ignored")
+            .expect("Failed to write file");
+
+        fs::write(
+            project_dir.join(".teamtypeignore"),
+            b"secret.txt\nignored_dir/\n*.log\n",
+        )
+        .expect("Failed to write .teamtypeignore");
+
+        let app_config = AppConfig {
+            base_dir: project_dir,
+            ..Default::default()
+        };
+
+        let files = enumerate_non_ignored_files(&app_config);
+        let file_names: Vec<&str> = files
+            .iter()
+            .filter_map(|p| p.file_name())
+            .filter_map(|n| n.to_str())
+            .collect();
+
+        // assertions:
+        assert!(
+            file_names.contains(&"a.txt"),
+            "a.txt should be in the list of files"
+        );
+        assert!(
+            file_names.contains(&"b.txt"),
+            "b.txt should be in the list of files"
+        );
+        assert!(
+            !file_names.contains(&"secret.txt"),
+            "secret.txt should be ignored by .teamtypeignore"
+        );
+        assert!(
+            !file_names.contains(&"ignored_dir"),
+            "ignored_dir should be ignored by .teamtypeignore"
+        );
+        assert!(
+            !file_names.contains(&"debug.log"),
+            "debug.log should be ignored by .teamtypeignore"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Added support for customer `.teamtypeignore` file in addition to .gitignore file.

This is also possible in syncthing for example with .stignore for files which should not be synced but also should not appear in .gitignore.

The syntax is similar to `.gitignore`, supporting file names, directories, and glob patterns.

- [x] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [?] I have added myself to the REUSE headers in the files where I made significant changes.
- [ ] I have used generative AI/LLMs for producing this PR. Here's which tool I used, and to which extent:
- [x] I have reviewed the output carefully, and I understand the resulting changes in detail. I am responsible for the changes, and I made sure that my PR represents excellent work.