### PR TITLE
chore(release): Linux-archive renamed to better reflect content

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,10 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            archive: $bin-x86_64-linux-static
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
+            archive: $bin-aarch64-linux-static
           - target: universal-apple-darwin
             os: macos-latest
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Add support for JSON-RPC IDs in string to be compliant with the [JSON-RPC specification](https://www.jsonrpc.org/specification).
 
+## Note for package maintainers: Renamed the Linux binaries
+
+We've renamed the Linux binaries
+- `teamtype-x86_64-unknown-linux-musl` to `teamtype-x86_64-linux-static`
+- `teamtype-aarch64-unknown-linux-musl` to `teamtype-aarch64-linux-static`
+
 # 0.9.1 (2026-01-28)
 
 *Teamtype enables real-time collaborative editing of local text files, in an editor-agnostic way.*


### PR DESCRIPTION
This removes the musl-suffix from the linux archive which has led to confusion as per #502.

This fixes #502

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

If your pull request aims to fix an open issue or bug,
please also link the relevant issue below this line.
You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.

Try to keep your PR small, split them up into multiple ones if applicable.

See https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md for more guidance.
-->

- [ ] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [ ] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes.
- [ ] I have used generative AI/LLMs for producing this PR. Here's which tool I used, and to which extent:
    - [ ] I have reviewed the output carefully, and I understand the resulting changes in detail. I am responsible for the changes, and I made sure that my PR represents excellent work.
