### PR TITLE
[WIP] Add optional custom iroh relay server url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Add support for JSON-RPC IDs in string to be compliant with the [JSON-RPC specification](https://www.jsonrpc.org/specification).
 
+## Add option to use a custom Iroh relay server
+
+You can now specify your own self-hosted Iroh relay server using the `--iroh-relay <url>` CLI flag on `share`/`join`, or by setting `iroh_relay = <url>` in `.teamtype/config`.
+
 ## Note for package maintainers: Renamed the Linux binaries
 
 We've renamed the Linux binaries

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -15,6 +15,7 @@ peer = <secret_address>
 emit_join_code = <true/false>
 emit_secret_address = <true/false>
 magic_wormhole_relay = <magic_wormhole_mailbox_relay_url>
+iroh_relay = <iroh_relay_server_url>
 ```
 
 After a successful `teamtype join`, the peer's secret address is automatically stored in your `.teamtype/config`.

--- a/daemon/src/cli.rs
+++ b/daemon/src/cli.rs
@@ -46,6 +46,9 @@ pub struct ShareJoinFlags {
     /// Use an alternative Magic Wormhole mailbox server relay url
     #[arg(long)]
     pub magic_wormhole_relay: Option<String>,
+    /// Use an alternative Iroh relay server url
+    #[arg(long)]
+    pub iroh_relay: Option<String>,
     #[arg(long)]
     /// The name that others see next to your cursor. Defaults to your Git username.
     pub username: Option<String>,

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -40,6 +40,7 @@ pub struct AppConfig {
     pub emit_join_code: bool,
     pub emit_secret_address: bool,
     pub magic_wormhole_relay: Option<String>,
+    pub iroh_relay: Option<String>,
     // Whether to sync version control directories like .git, .jj, ...
     pub sync_vcs: bool,
     pub username: Option<String>,
@@ -98,6 +99,9 @@ impl AppConfig {
                     .get("magic_wormhole_relay")
                     .map(ToString::to_string)
             }),
+            iroh_relay: app_config_cli
+                .iroh_relay
+                .or_else(|| general_section.get("iroh_relay").map(ToString::to_string)),
             sync_vcs: app_config_cli.sync_vcs,
             username: Some(username),
         }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -969,9 +969,13 @@ impl Daemon {
         }
 
         // Start connection manager.
-        let connection_manager = peer::ConnectionManager::new(document_handle.clone(), &base_dir)
-            .await
-            .expect("Failed to start connection manager");
+        let connection_manager = peer::ConnectionManager::new(
+            document_handle.clone(),
+            &base_dir,
+            app_config.iroh_relay.clone(),
+        )
+        .await
+        .expect("Failed to start connection manager");
         let address = connection_manager.secret_address();
 
         if app_config.emit_secret_address {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -80,6 +80,7 @@ async fn main() -> Result<()> {
                     shared_flags:
                         ShareJoinFlags {
                             magic_wormhole_relay,
+                            iroh_relay,
                             sync_vcs,
                             username,
                             ..
@@ -95,6 +96,7 @@ async fn main() -> Result<()> {
                         emit_join_code: !no_join_code,
                         emit_secret_address: show_secret_address,
                         magic_wormhole_relay,
+                        iroh_relay,
                         sync_vcs,
                         username,
                     };
@@ -108,6 +110,7 @@ async fn main() -> Result<()> {
                     shared_flags:
                         ShareJoinFlags {
                             magic_wormhole_relay,
+                            iroh_relay,
                             sync_vcs,
                             username,
                             ..
@@ -120,6 +123,7 @@ async fn main() -> Result<()> {
                         emit_join_code: false,
                         emit_secret_address: false,
                         magic_wormhole_relay,
+                        iroh_relay,
                         sync_vcs,
                         username,
                     };

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -60,10 +60,14 @@ pub struct ConnectionManager {
 }
 
 impl ConnectionManager {
-    pub async fn new(document_handle: DocumentActorHandle, base_dir: &Path) -> Result<Self> {
+    pub async fn new(
+        document_handle: DocumentActorHandle,
+        base_dir: &Path,
+        iroh_relay: Option<String>,
+    ) -> Result<Self> {
         let (message_tx, message_rx) = mpsc::channel(1);
 
-        let (endpoint, my_passphrase) = Self::build_endpoint(base_dir).await?;
+        let (endpoint, my_passphrase) = Self::build_endpoint(base_dir, iroh_relay).await?;
 
         let secret_address = format!("{}#{}", endpoint.node_id(), my_passphrase);
 
@@ -105,15 +109,25 @@ impl ConnectionManager {
         Ok(())
     }
 
-    async fn build_endpoint(base_dir: &Path) -> Result<(iroh::Endpoint, SecretKey)> {
+    async fn build_endpoint(
+        base_dir: &Path,
+        iroh_relay: Option<String>,
+    ) -> Result<(iroh::Endpoint, SecretKey)> {
         let (secret_key, my_passphrase) = Self::get_keypair(base_dir);
 
-        let endpoint = iroh::Endpoint::builder()
+        let mut builder = iroh::Endpoint::builder()
             .secret_key(secret_key)
             .alpns(vec![ALPN.to_vec()])
-            .discovery_n0()
-            .bind()
-            .await?;
+            .discovery_n0();
+
+        if let Some(url) = iroh_relay {
+            let relay_url: iroh::RelayUrl =
+                url.parse().context("Failed to parse iroh relay URL")?;
+            let relay_map = iroh::RelayMap::from(relay_url);
+            builder = builder.relay_mode(iroh::RelayMode::Custom(relay_map));
+        }
+
+        let endpoint = builder.bind().await?;
 
         Ok((endpoint, my_passphrase))
     }


### PR DESCRIPTION
## Summary
Added optional functionality to specify your own custom iroh server. 
This PR enables an optional configuration and command line argument to specify a custom iroh relay server. If not configured, teamtype will use the default iroh n0 servers.

To configure a custom relay you can either use the command line argument:

teamtype share --iroh-relay http://localhost:3340/

or by adding it to the .teamtype/config file

peer=6d02...2f4587
iroh_relay=http://localhost:3340/

## Why this change
Same reasons as [https://github.com/teamtype/teamtype/pull/446](https://github.com/teamtype/teamtype/pull/446)

## **Self-review checklist**

- [ x ] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [ x ] I have manually tested and self-reviewed my changes.
- [ x ] I have added myself to the REUSE headers in the files where I made significant changes.
- [ x ] I have used generative AI/LLMs for producing this PR. Here's which tool I used, and to which extent: Claude Code, 
    - [ x ] I have reviewed the output carefully, and I understand the resulting changes in detail. I am responsible for the changes, and I made sure that my PR represents excellent work.
