### PR TITLE
Make the iroh-relay and the iroh-dns-server configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Add support for JSON-RPC IDs in string to be compliant with the [JSON-RPC specif
 
 Add support for `.teamtypeignore` file to exclude files and directories from synchronization. The syntax is similar to `.gitignore`, supporting file names, directories, and glob patterns.
 
+Make iroh-relay and iroh-dns-server configurable, enabling fully self-hosted infrastructure.
+
 ## Note for package maintainers: Renamed the Linux binaries
 
 We've renamed the Linux binaries

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -15,6 +15,8 @@ peer = <secret_address>
 emit_join_code = <true/false>
 emit_secret_address = <true/false>
 magic_wormhole_relay = <magic_wormhole_mailbox_relay_url>
+relay = <iroh_relay_url>
+discovery = <pkarr_discovery_relay_url>
 ```
 
 After a successful `teamtype join`, the peer's secret address is automatically stored in your `.teamtype/config`.

--- a/book/src/connection-making.md
+++ b/book/src/connection-making.md
@@ -24,6 +24,31 @@ Since version 0.7.0 Teamtype uses iroh for making a connection. To connect to an
 
 You can directly connect across different local networks, even when each of you is behind a router. This way of connecting is more "ad hoc" and useful if you want to collaborate over a short period of time (as described in more detail in the [pair programming scenario](pair-programming.md)).
 
+## Self-hosted infrastructure
+
+By default, Teamtype uses infrastructure operated by [number zero (n0)](https://www.n0.computer/) for peer-to-peer connectivity:
+
+- An **iroh relay server** — proxies QUIC traffic when a direct connection between peers cannot be established (e.g. both behind NAT).
+- A **pkarr discovery relay** — publishes and resolves node addressing information so peers can find each other given only a node ID.
+
+You can replace both with self-hosted alternatives using the `--relay` and `--discovery` flags, or by adding them to your [configuration file](configuration.md):
+
+```bash
+teamtype share --relay https://relay.example.com --discovery https://relay.example.com/pkarr
+teamtype join 3-exhausted-bananas --relay https://relay.example.com --discovery https://relay.example.com/pkarr
+```
+
+**Both peers must use the same relay and discovery URLs.** If the host configures custom infrastructure, the joining peer must also pass the same URLs — otherwise they will not be able to find each other.
+
+You can use each flag independently:
+- `--relay` only: custom relay server, n0's discovery.
+- `--discovery` only: n0's relay servers, custom discovery.
+- Both: fully self-hosted, no dependency on n0's infrastructure.
+
+To run your own infrastructure, see:
+- **iroh relay server**: [github.com/n0-computer/iroh](https://github.com/n0-computer/iroh) (`iroh-relay` crate)
+- **pkarr relay server**: [github.com/Nuhvi/pkarr](https://github.com/Nuhvi/pkarr)
+
 ## Cloud peer
 
 When you want to have an "always online" host, such that every user can connect to it at the time of their liking, let's say you're collaborating in a group on [taking notes](shared-notes.md).

--- a/daemon/src/cli.rs
+++ b/daemon/src/cli.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2025 zormit <nt4u@kpvn.de>
 // SPDX-FileCopyrightText: 2026 axelmartensson <axel.martensson@hotmail.com>
+// SPDX-FileCopyrightText: 2026 TNG Technology Consulting GmbH <christoph.niehoff@tngtech.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -46,6 +47,14 @@ pub struct ShareJoinFlags {
     /// Use an alternative Magic Wormhole mailbox server relay url
     #[arg(long)]
     pub magic_wormhole_relay: Option<String>,
+    /// Use an alternative iroh relay server URL for peer-to-peer connections.
+    /// When set, replaces n0's default relay servers. Format: https://relay.example.com
+    #[arg(long)]
+    pub relay: Option<String>,
+    /// Use an alternative pkarr discovery relay URL for node address publishing and resolving.
+    /// When set, replaces n0's default discovery infrastructure. Format: https://discovery.example.com/pkarr
+    #[arg(long)]
+    pub discovery: Option<String>,
     #[arg(long)]
     /// The name that others see next to your cursor. Defaults to your Git username.
     pub username: Option<String>,

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -103,12 +103,12 @@ impl AppConfig {
                     .get("magic_wormhole_relay")
                     .map(ToString::to_string)
             }),
-            relay: app_config_cli.relay.or_else(|| {
-                general_section.get("relay").map(ToString::to_string)
-            }),
-            discovery: app_config_cli.discovery.or_else(|| {
-                general_section.get("discovery").map(ToString::to_string)
-            }),
+            relay: app_config_cli
+                .relay
+                .or_else(|| general_section.get("relay").map(ToString::to_string)),
+            discovery: app_config_cli
+                .discovery
+                .or_else(|| general_section.get("discovery").map(ToString::to_string)),
             sync_vcs: app_config_cli.sync_vcs,
             username: Some(username),
         }

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2025 zormit <nt4u@kpvn.de>
 // SPDX-FileCopyrightText: 2026 axelmartensson <axel.martensson@hotmail.com>
+// SPDX-FileCopyrightText: 2026 TNG Technology Consulting GmbH <christoph.niehoff@tngtech.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -40,6 +41,10 @@ pub struct AppConfig {
     pub emit_join_code: bool,
     pub emit_secret_address: bool,
     pub magic_wormhole_relay: Option<String>,
+    /// Custom iroh relay server URL. When set, replaces n0's default relay servers.
+    pub relay: Option<String>,
+    /// Custom pkarr discovery relay URL. When set, replaces n0's default discovery infrastructure.
+    pub discovery: Option<String>,
     // Whether to sync version control directories like .git, .jj, ...
     pub sync_vcs: bool,
     pub username: Option<String>,
@@ -97,6 +102,12 @@ impl AppConfig {
                 general_section
                     .get("magic_wormhole_relay")
                     .map(ToString::to_string)
+            }),
+            relay: app_config_cli.relay.or_else(|| {
+                general_section.get("relay").map(ToString::to_string)
+            }),
+            discovery: app_config_cli.discovery.or_else(|| {
+                general_section.get("discovery").map(ToString::to_string)
             }),
             sync_vcs: app_config_cli.sync_vcs,
             username: Some(username),
@@ -294,4 +305,169 @@ pub fn ensure_teamtype_is_ignored(directory: &Path) -> Result<()> {
         add_teamtype_to_local_gitignore(directory)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use tempfile::tempdir;
+
+    /// Write an INI-format config file into `<base_dir>/.teamtype/config`.
+    fn write_teamtype_config(base_dir: &Path, content: &str) {
+        let config_dir = base_dir.join(CONFIG_DIR);
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join(CONFIG_FILE), content).unwrap();
+    }
+
+    /// Build a minimal CLI AppConfig with only base_dir set, everything else defaulted.
+    fn cli_config(base_dir: &Path) -> AppConfig {
+        AppConfig {
+            base_dir: base_dir.to_path_buf(),
+            ..Default::default()
+        }
+    }
+
+    // ── relay ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn relay_absent_when_neither_cli_nor_config_file_set() {
+        let dir = tempdir().unwrap();
+        let result = AppConfig::from_config_file_and_cli(cli_config(dir.path()));
+        assert_eq!(result.relay, None);
+    }
+
+    #[test]
+    fn relay_taken_from_cli() {
+        let dir = tempdir().unwrap();
+        let mut config = cli_config(dir.path());
+        config.relay = Some("https://relay.cli.example.com".to_string());
+
+        let result = AppConfig::from_config_file_and_cli(config);
+        assert_eq!(
+            result.relay.as_deref(),
+            Some("https://relay.cli.example.com")
+        );
+    }
+
+    #[test]
+    fn relay_taken_from_config_file() {
+        let dir = tempdir().unwrap();
+        write_teamtype_config(dir.path(), "relay = https://relay.file.example.com\n");
+
+        let result = AppConfig::from_config_file_and_cli(cli_config(dir.path()));
+        assert_eq!(
+            result.relay.as_deref(),
+            Some("https://relay.file.example.com")
+        );
+    }
+
+    #[test]
+    fn relay_cli_takes_precedence_over_config_file() {
+        let dir = tempdir().unwrap();
+        write_teamtype_config(dir.path(), "relay = https://relay.file.example.com\n");
+
+        let mut config = cli_config(dir.path());
+        config.relay = Some("https://relay.cli.example.com".to_string());
+
+        let result = AppConfig::from_config_file_and_cli(config);
+        assert_eq!(
+            result.relay.as_deref(),
+            Some("https://relay.cli.example.com")
+        );
+    }
+
+    // ── discovery ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn discovery_absent_when_neither_cli_nor_config_file_set() {
+        let dir = tempdir().unwrap();
+        let result = AppConfig::from_config_file_and_cli(cli_config(dir.path()));
+        assert_eq!(result.discovery, None);
+    }
+
+    #[test]
+    fn discovery_taken_from_cli() {
+        let dir = tempdir().unwrap();
+        let mut config = cli_config(dir.path());
+        config.discovery = Some("https://discovery.cli.example.com/pkarr".to_string());
+
+        let result = AppConfig::from_config_file_and_cli(config);
+        assert_eq!(
+            result.discovery.as_deref(),
+            Some("https://discovery.cli.example.com/pkarr")
+        );
+    }
+
+    #[test]
+    fn discovery_taken_from_config_file() {
+        let dir = tempdir().unwrap();
+        write_teamtype_config(
+            dir.path(),
+            "discovery = https://discovery.file.example.com/pkarr\n",
+        );
+
+        let result = AppConfig::from_config_file_and_cli(cli_config(dir.path()));
+        assert_eq!(
+            result.discovery.as_deref(),
+            Some("https://discovery.file.example.com/pkarr")
+        );
+    }
+
+    #[test]
+    fn discovery_cli_takes_precedence_over_config_file() {
+        let dir = tempdir().unwrap();
+        write_teamtype_config(
+            dir.path(),
+            "discovery = https://discovery.file.example.com/pkarr\n",
+        );
+
+        let mut config = cli_config(dir.path());
+        config.discovery = Some("https://discovery.cli.example.com/pkarr".to_string());
+
+        let result = AppConfig::from_config_file_and_cli(config);
+        assert_eq!(
+            result.discovery.as_deref(),
+            Some("https://discovery.cli.example.com/pkarr")
+        );
+    }
+
+    // ── relay + discovery together ─────────────────────────────────────────────
+
+    #[test]
+    fn relay_and_discovery_both_taken_from_cli() {
+        let dir = tempdir().unwrap();
+        let mut config = cli_config(dir.path());
+        config.relay = Some("https://relay.cli.example.com".to_string());
+        config.discovery = Some("https://discovery.cli.example.com/pkarr".to_string());
+
+        let result = AppConfig::from_config_file_and_cli(config);
+        assert_eq!(
+            result.relay.as_deref(),
+            Some("https://relay.cli.example.com")
+        );
+        assert_eq!(
+            result.discovery.as_deref(),
+            Some("https://discovery.cli.example.com/pkarr")
+        );
+    }
+
+    #[test]
+    fn relay_and_discovery_both_taken_from_config_file() {
+        let dir = tempdir().unwrap();
+        write_teamtype_config(
+            dir.path(),
+            "relay = https://relay.file.example.com\ndiscovery = https://discovery.file.example.com/pkarr\n",
+        );
+
+        let result = AppConfig::from_config_file_and_cli(cli_config(dir.path()));
+        assert_eq!(
+            result.relay.as_deref(),
+            Some("https://relay.file.example.com")
+        );
+        assert_eq!(
+            result.discovery.as_deref(),
+            Some("https://discovery.file.example.com/pkarr")
+        );
+    }
 }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 TNG Technology Consulting GmbH <christoph.niehoff@tngtech.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -969,9 +970,14 @@ impl Daemon {
         }
 
         // Start connection manager.
-        let connection_manager = peer::ConnectionManager::new(document_handle.clone(), &base_dir)
-            .await
-            .expect("Failed to start connection manager");
+        let connection_manager = peer::ConnectionManager::new(
+            document_handle.clone(),
+            &base_dir,
+            app_config.relay.clone(),
+            app_config.discovery.clone(),
+        )
+        .await
+        .expect("Failed to start connection manager");
         let address = connection_manager.secret_address();
 
         if app_config.emit_secret_address {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
 // SPDX-FileCopyrightText: 2026 axelmartensson <axel.martensson@hotmail.com>
+// SPDX-FileCopyrightText: 2026 TNG Technology Consulting GmbH <christoph.niehoff@tngtech.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -80,6 +81,8 @@ async fn main() -> Result<()> {
                     shared_flags:
                         ShareJoinFlags {
                             magic_wormhole_relay,
+                            relay,
+                            discovery,
                             sync_vcs,
                             username,
                             ..
@@ -95,6 +98,8 @@ async fn main() -> Result<()> {
                         emit_join_code: !no_join_code,
                         emit_secret_address: show_secret_address,
                         magic_wormhole_relay,
+                        relay,
+                        discovery,
                         sync_vcs,
                         username,
                     };
@@ -108,6 +113,8 @@ async fn main() -> Result<()> {
                     shared_flags:
                         ShareJoinFlags {
                             magic_wormhole_relay,
+                            relay,
+                            discovery,
                             sync_vcs,
                             username,
                             ..
@@ -120,6 +127,8 @@ async fn main() -> Result<()> {
                         emit_join_code: false,
                         emit_secret_address: false,
                         magic_wormhole_relay,
+                        relay,
+                        discovery,
                         sync_vcs,
                         username,
                     };

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 TNG Technology Consulting GmbH <christoph.niehoff@tngtech.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -9,8 +10,9 @@ use self::sync::{Connection, PeerMessage, SyncActor};
 use crate::daemon::DocumentActorHandle;
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
-use iroh::endpoint::{RecvStream, SendStream};
-use iroh::{NodeAddr, SecretKey};
+use iroh::endpoint::{RecvStream, RelayMode, SendStream};
+use iroh::{NodeAddr, RelayMap, RelayUrl, SecretKey};
+use iroh::discovery::{ConcurrentDiscovery, dns::DnsDiscovery, pkarr::{PkarrPublisher, PkarrResolver}};
 use postcard::{from_bytes, to_allocvec};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
@@ -60,10 +62,15 @@ pub struct ConnectionManager {
 }
 
 impl ConnectionManager {
-    pub async fn new(document_handle: DocumentActorHandle, base_dir: &Path) -> Result<Self> {
+    pub async fn new(
+        document_handle: DocumentActorHandle,
+        base_dir: &Path,
+        relay: Option<String>,
+        discovery: Option<String>,
+    ) -> Result<Self> {
         let (message_tx, message_rx) = mpsc::channel(1);
 
-        let (endpoint, my_passphrase) = Self::build_endpoint(base_dir).await?;
+        let (endpoint, my_passphrase) = Self::build_endpoint(base_dir, relay, discovery).await?;
 
         let secret_address = format!("{}#{}", endpoint.node_id(), my_passphrase);
 
@@ -105,16 +112,50 @@ impl ConnectionManager {
         Ok(())
     }
 
-    async fn build_endpoint(base_dir: &Path) -> Result<(iroh::Endpoint, SecretKey)> {
+    async fn build_endpoint(
+        base_dir: &Path,
+        relay: Option<String>,
+        discovery: Option<String>,
+    ) -> Result<(iroh::Endpoint, SecretKey)> {
         let (secret_key, my_passphrase) = Self::get_keypair(base_dir);
 
-        let endpoint = iroh::Endpoint::builder()
-            .secret_key(secret_key)
-            .alpns(vec![ALPN.to_vec()])
-            .discovery_n0()
-            .bind()
-            .await?;
+        let mut builder = iroh::Endpoint::builder()
+            .secret_key(secret_key.clone())
+            .alpns(vec![ALPN.to_vec()]);
 
+        match (&relay, &discovery) {
+            (None, None) => {
+                // Default: use n0's infrastructure (current behavior).
+                builder = builder.discovery_n0();
+            }
+            _ => {
+                // Custom: configure relay and discovery separately.
+                if let Some(relay_url) = &relay {
+                    let url: RelayUrl = relay_url.parse()?;
+                    let relay_map = RelayMap::from(url);
+                    builder = builder.relay_mode(RelayMode::Custom(relay_map));
+                    info!("Using custom iroh relay: {}", relay_url);
+                }
+
+                if let Some(discovery_url) = &discovery {
+                    let pkarr_url: url::Url = discovery_url.parse()?;
+                    let concurrent = ConcurrentDiscovery::from_services(vec![
+                        Box::new(PkarrPublisher::new(secret_key.clone(), pkarr_url.clone())),
+                        Box::new(PkarrResolver::new(pkarr_url)),
+                    ]);
+                    builder = builder.discovery(Box::new(concurrent));
+                    info!("Using custom pkarr discovery: {}", discovery_url);
+                } else {
+                    // relay is set but discovery is not: keep n0's discovery services.
+                    builder = builder
+                        .add_discovery(|sk| Some(PkarrPublisher::n0_dns(sk.clone())))
+                        .add_discovery(|_| Some(PkarrResolver::n0_dns()))
+                        .add_discovery(|_| Some(DnsDiscovery::n0_dns()));
+                }
+            }
+        }
+
+        let endpoint = builder.bind().await?;
         Ok((endpoint, my_passphrase))
     }
 
@@ -429,6 +470,113 @@ impl IrohConnection {
         let mut bytes = vec![0; byte_count as usize];
         receive.read_exact(&mut bytes).await?;
         from_bytes(&bytes).context("Failed to convert bytes to PeerMessage")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Create a temp dir with the `.teamtype/` subdirectory that `get_keypair` expects.
+    fn make_temp_base_dir() -> tempfile::TempDir {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".teamtype")).unwrap();
+        dir
+    }
+
+    // ── URL validation ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn build_endpoint_invalid_relay_url_returns_error() {
+        let dir = make_temp_base_dir();
+        let result =
+            ConnectionManager::build_endpoint(dir.path(), Some("not-a-url".to_string()), None)
+                .await;
+        assert!(result.is_err(), "expected Err for invalid relay URL");
+    }
+
+    #[tokio::test]
+    async fn build_endpoint_invalid_discovery_url_returns_error() {
+        let dir = make_temp_base_dir();
+        let result =
+            ConnectionManager::build_endpoint(dir.path(), None, Some("not-a-url".to_string()))
+                .await;
+        assert!(result.is_err(), "expected Err for invalid discovery URL");
+    }
+
+    // ── successful builds ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn build_endpoint_default_succeeds_and_has_discovery() {
+        let dir = make_temp_base_dir();
+        let (endpoint, _passphrase) =
+            ConnectionManager::build_endpoint(dir.path(), None, None)
+                .await
+                .expect("default build_endpoint should succeed");
+
+        // n0's discovery_n0() always installs a discovery service.
+        assert!(
+            endpoint.discovery().is_some(),
+            "default endpoint should have discovery configured"
+        );
+        endpoint.close().await;
+    }
+
+    #[tokio::test]
+    async fn build_endpoint_custom_relay_succeeds_and_retains_discovery() {
+        let dir = make_temp_base_dir();
+        // Use an unreachable URL: bind() succeeds since relay connection is lazy.
+        let (endpoint, _passphrase) = ConnectionManager::build_endpoint(
+            dir.path(),
+            Some("https://relay.example.com".to_string()),
+            None,
+        )
+        .await
+        .expect("custom-relay build_endpoint should succeed");
+
+        // When only relay is custom, we manually re-add the three n0 discovery services.
+        assert!(
+            endpoint.discovery().is_some(),
+            "custom-relay endpoint should still have discovery configured"
+        );
+        endpoint.close().await;
+    }
+
+    #[tokio::test]
+    async fn build_endpoint_custom_discovery_succeeds_and_has_discovery() {
+        let dir = make_temp_base_dir();
+        let (endpoint, _passphrase) = ConnectionManager::build_endpoint(
+            dir.path(),
+            None,
+            Some("https://discovery.example.com/pkarr".to_string()),
+        )
+        .await
+        .expect("custom-discovery build_endpoint should succeed");
+
+        assert!(
+            endpoint.discovery().is_some(),
+            "custom-discovery endpoint should have discovery configured"
+        );
+        endpoint.close().await;
+    }
+
+    #[tokio::test]
+    async fn build_endpoint_both_custom_succeeds_and_has_discovery() {
+        let dir = make_temp_base_dir();
+        let (endpoint, _passphrase) = ConnectionManager::build_endpoint(
+            dir.path(),
+            Some("https://relay.example.com".to_string()),
+            Some("https://discovery.example.com/pkarr".to_string()),
+        )
+        .await
+        .expect("fully-custom build_endpoint should succeed");
+
+        assert!(
+            endpoint.discovery().is_some(),
+            "fully-custom endpoint should have discovery configured"
+        );
+        endpoint.close().await;
     }
 }
 

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -10,9 +10,13 @@ use self::sync::{Connection, PeerMessage, SyncActor};
 use crate::daemon::DocumentActorHandle;
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
+use iroh::discovery::{
+    ConcurrentDiscovery,
+    dns::DnsDiscovery,
+    pkarr::{PkarrPublisher, PkarrResolver},
+};
 use iroh::endpoint::{RecvStream, RelayMode, SendStream};
 use iroh::{NodeAddr, RelayMap, RelayUrl, SecretKey};
-use iroh::discovery::{ConcurrentDiscovery, dns::DnsDiscovery, pkarr::{PkarrPublisher, PkarrResolver}};
 use postcard::{from_bytes, to_allocvec};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
@@ -510,10 +514,9 @@ mod tests {
     #[tokio::test]
     async fn build_endpoint_default_succeeds_and_has_discovery() {
         let dir = make_temp_base_dir();
-        let (endpoint, _passphrase) =
-            ConnectionManager::build_endpoint(dir.path(), None, None)
-                .await
-                .expect("default build_endpoint should succeed");
+        let (endpoint, _passphrase) = ConnectionManager::build_endpoint(dir.path(), None, None)
+            .await
+            .expect("default build_endpoint should succeed");
 
         // n0's discovery_n0() always installs a discovery service.
         assert!(


### PR DESCRIPTION
We would like to be able to teamtype completely self-hosted (i.e. without using magic wormhole or iroh servers).
This PR makes the iroh relay and the iroh DNS discovery server configurable, both, via CLI arguments and in the config file


**Self-review checklist**

- [X ] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [ X] I have manually tested and self-reviewed my changes.
- [ X] I have added myself to the REUSE headers in the files where I made significant changes.
- [ X] I have used generative AI/LLMs for producing this PR. Here's which tool I used, and to which extent:
  - OpenCode with Anthropic Claude Sonnet 4.6 and Claude Opus 4.6  
  - [X ] I have reviewed the output carefully, and I understand the resulting changes in detail. I am responsible for the changes, and I made sure that my PR represents excellent work.
