### PR TITLE
Make the Iroh relay configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Add support for JSON-RPC IDs in string to be compliant with the [JSON-RPC specif
 
 Add support for `.teamtypeignore` file to exclude files and directories from synchronization. The syntax is similar to `.gitignore`, supporting file names, directories, and glob patterns.
 
+Add support for custom Iroh relay servers, using the `--iroh-relay` flag.
+
 ## Note for package maintainers: Renamed the Linux binaries
 
 We've renamed the Linux binaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Add support for JSON-RPC IDs in string to be compliant with the [JSON-RPC specif
 
 Add support for `.teamtypeignore` file to exclude files and directories from synchronization. The syntax is similar to `.gitignore`, supporting file names, directories, and glob patterns.
 
-Add support for custom Iroh relay servers, using the `--iroh-relay` flag.
+Add support for custom Iroh relay servers, using the `--iroh-relay` flag, and for custom Iroh DNS discovery servers, using `--iroh-dns-domain` and `--iroh-pkarr-relay`. See the "Running your own relays" page in the documentation for how to run all these relays yourself!
 
 ## Note for package maintainers: Renamed the Linux binaries
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -29,6 +29,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
     - [Working with Git](git-integration.md)
         - [Manual](git-integration-manual.md)
         - [Synchronized](git-integration-synchronized.md)
+    - [Running your own relays](relays.md)
 - [Related projects](related-projects.md)
 
 # Developer documentation

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -12,10 +12,14 @@ You can put the following options into a configuration file at `.teamtype/config
 ```ini
 username = <string>
 peer = <secret_address>
+
 emit_join_code = <true/false>
 emit_secret_address = <true/false>
+
 magic_wormhole_relay = <magic_wormhole_mailbox_relay_url>
 iroh_relay = <iroh_relay_url>
+iroh_dns_domain = <iroh_dns_domain>
+iroh_pkarr_relay = <iroh_pkarr_relay>
 ```
 
 After a successful `teamtype join`, the peer's secret address is automatically stored in your `.teamtype/config`.

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -15,6 +15,7 @@ peer = <secret_address>
 emit_join_code = <true/false>
 emit_secret_address = <true/false>
 magic_wormhole_relay = <magic_wormhole_mailbox_relay_url>
+iroh_relay = <iroh_relay_url>
 ```
 
 After a successful `teamtype join`, the peer's secret address is automatically stored in your `.teamtype/config`.

--- a/book/src/connection-making.md
+++ b/book/src/connection-making.md
@@ -11,11 +11,6 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 When you run `teamtype share`, you will get a short "join code" like `3-exhausted-bananas`. Another person can use it to connect to you! The code only works once. You can learn about the security properties in the [Magic Wormhole documentation](https://magic-wormhole.readthedocs.io/en/latest/welcome.html#safely).
 
-You can make Teamtype use a custom [relay server](https://github.com/magic-wormhole/magic-wormhole-mailbox-server) with the optional `--magic-wormhole-relay` parameter or by adding it to your [configuration file](configuration.md).
-```bash
-teamtype share --magic-wormhole-relay ws://example.com:4000/v1
-```
-
 ## Secret addresses
 
 Since version 0.7.0 Teamtype uses iroh for making a connection. To connect to another daemon, we're using a combination of the iroh [Node Identifier](https://www.iroh.computer/docs/concepts/endpoint#node-identifiers) and a secret key which, smashed together, which looks like `429e94...0e9819#32374e...4a6789`. We call this the node's *secret address*. Treat it like a password. After using a join code, the secret address is stored in your `.teamtype/config`.

--- a/book/src/relays.md
+++ b/book/src/relays.md
@@ -1,0 +1,98 @@
+<!--
+SPDX-FileCopyrightText: 2026 blinry <mail@blinry.org>
+SPDX-FileCopyrightText: 2026 zormit <nt4u@kpvn.de>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Running your own relays
+
+By default, Teamtype uses a couple of public relays hosted by other people/groups. They facilitate smooth connections between devices in different local networks. All transmitted data is always end-to-end encrypted between peers. After a connection is established, peers connect directly, if possible.
+
+If you don't want to rely on these public relays, you can host your own ones, and instruct Teamtype to use them. Here's how that works for each of the relays. Note that we mostly describe a "development testing setup" here; for a production deployment, please look into the individual relays more carefully.
+
+## Magic Wormhole relay
+
+Teamtype uses a [Magic Wormhole relay server](https://github.com/magic-wormhole/magic-wormhole-mailbox-server) (also known as "mailbox server" or "rendezvous server") to share the initial join codes with other peers.
+
+### Running your own
+
+Install [uv](https://docs.astral.sh/uv/), then run:
+
+    uvx --from twisted --with magic-wormhole-mailbox-server twist wormhole-mailbox
+
+This will start the relay on port 4000 by default.
+
+### Using it
+
+Run
+
+    teamtype share --magic-wormhole-relay ws://localhost:4000/v1
+
+and
+
+    teamtype join --magic-wormhole-relay ws://localhost:4000/v1 <join code>
+
+or set the `magic_wormhole_relay` parameter in `.teamtype/config`.
+
+## Iroh Pkarr relay + DNS server
+
+Teamtype uses Iroh's [Pkarr relay and DNS server](https://github.com/n0-computer/iroh/tree/main/iroh-dns-server) to allow peers to meet on the same Iroh relay (see below). Read [Iroh's discovery documentation](https://docs.iroh.computer/concepts/discovery) for more information.
+
+### Running your own
+
+Using Rust's `cargo`, run `cargo install iroh-dns-server@0.35.0`. Then, run:
+
+    iroh-dns-server
+
+This will start a Pkarr relay on port 8080, and a DNS server on port 5300 by default, which resolves subdomains of `irohdns.example`. You can provide configuration files for production setups, see the [README of iroh-dns-server](https://github.com/n0-computer/iroh/tree/main/iroh-dns-server).
+
+### DNS testing setup
+
+For a development setup, you need to configure your computer to use your local DNS server. Assuming you're on Linux and use `systemd-resolved`, run
+
+    sudo resolvectl dns <interface> 127.0.0.1:5300
+
+to set sets it as a DNS server for a network interface, run `resolvectl status` for your options. Then, run
+
+    sudo resolvectl domain <interface> '~irohdns.example'
+
+so that only domains under `irohdns.example` are resolved using your local server.
+
+### Using it
+
+Run
+
+    teamtype share --iroh-pkarr-relay http://localhost:8080/pkarr
+
+and
+
+    teamtype join --iroh-dns-domain irohdns.example <join code>
+
+or set the `iroh_pkarr_relay` and `iroh_dns_domain` parameters in `.teamtype/config`.
+
+It doesn't hurt to use both flags on both the sharing and the joining peer.
+
+## Iroh relay
+
+Teamtype uses an [Iroh relay](https://github.com/n0-computer/iroh/tree/main/iroh-relay) when direct connections between peers aren't immediately possible. Read [Iroh's relay documentation](https://docs.iroh.computer/concepts/relays) for more information.
+
+### Running your own
+
+Using Rust's `cargo`, run `cargo install cargo install iroh-relay@0.35.0 --features=server`. Then, run:
+
+    iroh-relay --dev
+
+This will start the relay on port 3340 by default.
+
+### Using it
+
+Run
+
+    teamtype share --iroh-relay http://localhost:3340
+
+and
+
+    teamtype join --iroh-relay http://localhost:3340 <join code>
+
+or set the `iroh_relay` parameter in `.teamtype/config`.

--- a/daemon/src/cli.rs
+++ b/daemon/src/cli.rs
@@ -46,6 +46,9 @@ pub struct ShareJoinFlags {
     /// Use an alternative Magic Wormhole mailbox server relay url
     #[arg(long)]
     pub magic_wormhole_relay: Option<String>,
+    /// Use an alternative Iroh relay url
+    #[arg(long)]
+    pub iroh_relay: Option<String>,
     #[arg(long)]
     /// The name that others see next to your cursor. Defaults to your Git username.
     pub username: Option<String>,

--- a/daemon/src/cli.rs
+++ b/daemon/src/cli.rs
@@ -49,6 +49,12 @@ pub struct ShareJoinFlags {
     /// Use an alternative Iroh relay url
     #[arg(long)]
     pub iroh_relay: Option<String>,
+    /// Use an alternative Iroh DNS origin domain.
+    #[arg(long)]
+    pub iroh_dns_domain: Option<String>,
+    /// Use an alternative Iroh Pkarr relay server.
+    #[arg(long)]
+    pub iroh_pkarr_relay: Option<String>,
     #[arg(long)]
     /// The name that others see next to your cursor. Defaults to your Git username.
     pub username: Option<String>,

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -43,6 +43,7 @@ pub struct AppConfig {
     pub emit_join_code: bool,
     pub emit_secret_address: bool,
     pub magic_wormhole_relay: Option<String>,
+    pub iroh_relay: Option<String>,
     // Whether to sync version control directories like .git, .jj, ...
     pub sync_vcs: bool,
     pub username: Option<String>,
@@ -101,6 +102,9 @@ impl AppConfig {
                     .get("magic_wormhole_relay")
                     .map(ToString::to_string)
             }),
+            iroh_relay: app_config_cli
+                .iroh_relay
+                .or_else(|| general_section.get("iroh_relay").map(ToString::to_string)),
             sync_vcs: app_config_cli.sync_vcs,
             username: Some(username),
         }

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -44,6 +44,8 @@ pub struct AppConfig {
     pub emit_secret_address: bool,
     pub magic_wormhole_relay: Option<String>,
     pub iroh_relay: Option<String>,
+    pub iroh_dns_domain: Option<String>,
+    pub iroh_pkarr_relay: Option<String>,
     // Whether to sync version control directories like .git, .jj, ...
     pub sync_vcs: bool,
     pub username: Option<String>,
@@ -105,6 +107,16 @@ impl AppConfig {
             iroh_relay: app_config_cli
                 .iroh_relay
                 .or_else(|| general_section.get("iroh_relay").map(ToString::to_string)),
+            iroh_dns_domain: app_config_cli.iroh_dns_domain.or_else(|| {
+                general_section
+                    .get("iroh_dns_domain")
+                    .map(ToString::to_string)
+            }),
+            iroh_pkarr_relay: app_config_cli.iroh_pkarr_relay.or_else(|| {
+                general_section
+                    .get("iroh_pkarr_relay")
+                    .map(ToString::to_string)
+            }),
             sync_vcs: app_config_cli.sync_vcs,
             username: Some(username),
         }

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -972,9 +972,10 @@ impl Daemon {
         }
 
         // Start connection manager.
-        let connection_manager = peer::ConnectionManager::new(document_handle.clone(), &base_dir)
-            .await
-            .expect("Failed to start connection manager");
+        let connection_manager =
+            peer::ConnectionManager::new(&app_config, document_handle.clone(), &base_dir)
+                .await
+                .expect("Failed to start connection manager");
         let address = connection_manager.secret_address();
 
         if app_config.emit_secret_address {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -82,6 +82,7 @@ async fn main() -> Result<()> {
                     shared_flags:
                         ShareJoinFlags {
                             magic_wormhole_relay,
+                            iroh_relay,
                             sync_vcs,
                             username,
                             ..
@@ -97,6 +98,7 @@ async fn main() -> Result<()> {
                         emit_join_code: !no_join_code,
                         emit_secret_address: show_secret_address,
                         magic_wormhole_relay,
+                        iroh_relay,
                         sync_vcs,
                         username,
                     };
@@ -110,6 +112,7 @@ async fn main() -> Result<()> {
                     shared_flags:
                         ShareJoinFlags {
                             magic_wormhole_relay,
+                            iroh_relay,
                             sync_vcs,
                             username,
                             ..
@@ -122,6 +125,7 @@ async fn main() -> Result<()> {
                         emit_join_code: false,
                         emit_secret_address: false,
                         magic_wormhole_relay,
+                        iroh_relay,
                         sync_vcs,
                         username,
                     };

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -83,6 +83,8 @@ async fn main() -> Result<()> {
                         ShareJoinFlags {
                             magic_wormhole_relay,
                             iroh_relay,
+                            iroh_dns_domain,
+                            iroh_pkarr_relay,
                             sync_vcs,
                             username,
                             ..
@@ -99,6 +101,8 @@ async fn main() -> Result<()> {
                         emit_secret_address: show_secret_address,
                         magic_wormhole_relay,
                         iroh_relay,
+                        iroh_dns_domain,
+                        iroh_pkarr_relay,
                         sync_vcs,
                         username,
                     };
@@ -113,6 +117,8 @@ async fn main() -> Result<()> {
                         ShareJoinFlags {
                             magic_wormhole_relay,
                             iroh_relay,
+                            iroh_dns_domain,
+                            iroh_pkarr_relay,
                             sync_vcs,
                             username,
                             ..
@@ -126,6 +132,8 @@ async fn main() -> Result<()> {
                         emit_secret_address: false,
                         magic_wormhole_relay,
                         iroh_relay,
+                        iroh_dns_domain,
+                        iroh_pkarr_relay,
                         sync_vcs,
                         username,
                     };

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -15,13 +15,14 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use iroh::endpoint::{RecvStream, SendStream};
-use iroh::{NodeAddr, SecretKey};
+use iroh::{NodeAddr, RelayMap, RelayUrl, SecretKey};
 use postcard::{from_bytes, to_allocvec};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
 
 use self::sync::{Connection, PeerMessage, SyncActor};
+use crate::config::AppConfig;
 use crate::daemon::DocumentActorHandle;
 
 mod sync;
@@ -63,10 +64,14 @@ pub struct ConnectionManager {
 }
 
 impl ConnectionManager {
-    pub async fn new(document_handle: DocumentActorHandle, base_dir: &Path) -> Result<Self> {
+    pub async fn new(
+        app_config: &AppConfig,
+        document_handle: DocumentActorHandle,
+        base_dir: &Path,
+    ) -> Result<Self> {
         let (message_tx, message_rx) = mpsc::channel(1);
 
-        let (endpoint, my_passphrase) = Self::build_endpoint(base_dir).await?;
+        let (endpoint, my_passphrase) = Self::build_endpoint(app_config, base_dir).await?;
 
         let secret_address = format!("{}#{}", endpoint.node_id(), my_passphrase);
 
@@ -108,15 +113,24 @@ impl ConnectionManager {
         Ok(())
     }
 
-    async fn build_endpoint(base_dir: &Path) -> Result<(iroh::Endpoint, SecretKey)> {
+    async fn build_endpoint(
+        app_config: &AppConfig,
+        base_dir: &Path,
+    ) -> Result<(iroh::Endpoint, SecretKey)> {
         let (secret_key, my_passphrase) = Self::get_keypair(base_dir);
 
-        let endpoint = iroh::Endpoint::builder()
+        let mut builder = iroh::Endpoint::builder()
             .secret_key(secret_key)
             .alpns(vec![ALPN.to_vec()])
-            .discovery_n0()
-            .bind()
-            .await?;
+            .discovery_n0();
+
+        if let Some(iroh_relay) = &app_config.iroh_relay {
+            let relay_url = RelayUrl::from_str(iroh_relay)?;
+            let relay_map = RelayMap::from(relay_url);
+            builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(relay_map));
+        }
+
+        let endpoint = builder.bind().await?;
 
         Ok((endpoint, my_passphrase))
     }

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -14,12 +14,15 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
+use iroh::discovery::dns::DnsDiscovery;
+use iroh::discovery::pkarr::PkarrPublisher;
 use iroh::endpoint::{RecvStream, SendStream};
 use iroh::{NodeAddr, RelayMap, RelayUrl, SecretKey};
 use postcard::{from_bytes, to_allocvec};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
+use url::Url;
 
 use self::sync::{Connection, PeerMessage, SyncActor};
 use crate::config::AppConfig;
@@ -121,13 +124,33 @@ impl ConnectionManager {
 
         let mut builder = iroh::Endpoint::builder()
             .secret_key(secret_key)
-            .alpns(vec![ALPN.to_vec()])
-            .discovery_n0();
+            .alpns(vec![ALPN.to_vec()]);
 
         if let Some(iroh_relay) = &app_config.iroh_relay {
             let relay_url = RelayUrl::from_str(iroh_relay)?;
             let relay_map = RelayMap::from(relay_url);
             builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(relay_map));
+        }
+
+        if let Some(iroh_dns_domain) = &app_config.iroh_dns_domain {
+            let iroh_dns_domain_clone = iroh_dns_domain.clone();
+            builder =
+                builder.add_discovery(move |_| Some(DnsDiscovery::new(iroh_dns_domain_clone)));
+        } else {
+            builder = builder.add_discovery(move |_| Some(DnsDiscovery::n0_dns()));
+        }
+
+        if let Some(iroh_pkarr_relay) = &app_config.iroh_pkarr_relay {
+            let iroh_pkarr_relay_url = Url::parse(iroh_pkarr_relay)?;
+            builder = builder.add_discovery(|secret_key| {
+                Some(PkarrPublisher::new(
+                    secret_key.clone(),
+                    iroh_pkarr_relay_url,
+                ))
+            });
+        } else {
+            builder = builder
+                .add_discovery(|secret_key| Some(PkarrPublisher::n0_dns(secret_key.clone())));
         }
 
         let endpoint = builder.bind().await?;


### PR DESCRIPTION
This addresses #344, and is an alternative to #512 and #517.

## Testing

To try this:

- clone https://github.com/n0-computer/iroh
- check out the `v0.35.0` tag
- go to `iroh-relay/`
- run `cargo run --features=server -r -- --dev`
- run `teamtype share --iroh-relay http://localhost:3340`, or the respective `join` command

Seems to work for me! :tada:

(See below for DNS + Pkarr relay.)

## Still to do

- [x] Figure out whether we also need/want a flag for custom servers for discovery. -> definitely
- [x] Confirm whether Teamtype then really works without any external servers.
- [x] Document how to run your own relays.

Ideally, we'd provide a `teamtype relay` subcommand, which spins up all required relays and services ourselves – let's probably do that in a follow-up PR.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

If your pull request aims to fix an open issue or bug,
please also link the relevant issue below this line.
You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.

Try to keep your PR small, split them up into multiple ones if applicable.

See https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md for more guidance.
-->

## Self-review checklist

- [x] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).