### PR TITLE
Fixup docs generation (local and doc.rs) and include README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The [releases on GitHub](https://github.com/teamtype/teamtype/releases/latest) c
 <details>
 <summary>Arch Linux</summary>
 
-```
+```bash
 sudo pacman -S teamtype
 ```
 </details>
@@ -65,7 +65,7 @@ sudo pacman -S teamtype
 <details>
 <summary>Homebrew</summary>
 
-```
+```bash
 brew install teamtype
 ```
 </details>
@@ -75,7 +75,7 @@ brew install teamtype
 
 To put `teamtype` in your PATH temporarily, run:
 
-```
+```bash
 nix shell nixpkgs#teamtype
 ```
 
@@ -106,7 +106,7 @@ cargo binstall teamtype
 
 In the directory you want to share:
 
-```
+```console
 $ teamtype share
 
     To connect to you, another person can run:
@@ -118,7 +118,7 @@ Peer connected: adfa90edd932732ddf242f24dc2dcd6156779e69966d432fcb3b9fe3ae9831ab
 
 Another person, in a separate directory (also works on the same computer):
 
-```
+```console
 $ teamtype join 5-hamburger-endorse
 
 Derived peer from join code. Storing in config (overwriting previous config).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 *Multiplayer mode for your text editor!*
 
+For complete end-user documentation see the [Teamtype Documentation][docs] site.
+
 > [!NOTE]
 > This project used to be called "Ethersync" until October 2025. See [this PR](https://github.com/teamtype/teamtype/pull/436) for our motivation.
 
@@ -23,7 +25,7 @@ Teamtype enables real-time collaborative editing of local text files. You can us
 - 🗃️ Work on entire projects, the way you're used to
 - 🔒 Encrypted peer-to-peer connections, no need for a server
 - ✒️ Local-first: You always have full access, even offline
-- 🧩 [Simple JSON-RPC protocol](https://teamtype.github.io/teamtype/editor-plugin-dev-guide.html) for writing new editor plugins
+- 🧩 [Simple JSON-RPC protocol][editor-plugin-dev-guide] for writing new editor plugins
 
 We also maintain a list of [other collaborative text-editing software](https://teamtype.github.io/teamtype/related-projects.html).
 
@@ -130,7 +132,7 @@ The directories are now connected, and changes will be synced instantly. You can
 
 ## 🎓 Learn more
 
-- Learn more about Teamtype in [the documentation](https://teamtype.github.io/teamtype).
+- Learn more about Teamtype in [the documentation][docs].
 - Watch a [10-minute talk](https://fosdem.org/2025/schedule/event/fosdem-2025-4890-ethersync-real-time-collaboration-in-your-text-editor-/) given at FOSDEM 2025.
 - Watch a (German) [1-hour talk](https://media.ccc.de/v/2024-355-ethersync-echtzeit-kollaboration-in-deinem-texteditor-) given at MRMCD 2024.
 
@@ -195,3 +197,6 @@ And finally, thanks to everyone who helped us beta-test, or reported issues!
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
 This project is [REUSE](https://reuse.software) compliant, see the headers of each file for licensing information.
+
+[docs]: https://teamtype.github.io/teamtype
+[editor-plugin-dev-guide]: https://teamtype.github.io/teamtype/editor-plugin-dev-guide.html

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -31,7 +31,6 @@ default-run = "teamtype"
 name = "teamtype"
 test = false
 bench = false
-doc = false
 required-features = ["executable-deps"]
 
 [lib]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -27,9 +27,6 @@ edition = "2024"
 rust-version = "1.89.0"
 default-run = "teamtype"
 
-[lib]
-name = "teamtype"
-
 [[bin]]
 name = "teamtype"
 test = false
@@ -37,33 +34,12 @@ bench = false
 doc = false
 required-features = ["executable-deps"]
 
+[lib]
+name = "teamtype"
+
 [features]
 default = ["executable-deps"]
 executable-deps = ["dep:clap", "tokio/signal", "tokio/rt-multi-thread"]
-
-[lints.rust]
-unsafe_code = "forbid"
-unused_qualifications = "warn"
-[lints.clippy]
-pedantic = { level = "warn", priority = -1 }
-nursery = { level = "warn", priority = -1 }
-allow_attributes = "warn"
-map_with_unused_argument_over_ranges = "warn"
-
-too_long_first_doc_paragraph = "allow"
-
-# TODO: add 'expect' to the places where casts are happening and enable the lints
-cast_possible_truncation = "allow"
-cast_possible_wrap = "allow"
-cast_sign_loss = "allow"
-
-cognitive_complexity = "allow"
-missing_const_for_fn = "allow"
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-must_use_candidate = "allow"
-should_panic_without_expect = "allow"
-too_many_lines = "allow"
 
 [build-dependencies]
 anyhow = "1"
@@ -138,3 +114,25 @@ inherits = "release"
 lto = true
 codegen-units = 1
 opt-level = "s"
+
+[lints.rust]
+unsafe_code = "forbid"
+unused_qualifications = "warn"
+
+[lints.clippy]
+allow_attributes = "warn"
+# TODO: add 'expect' to the places where casts are happening and enable the lints
+cast_possible_truncation = "allow"
+cast_possible_wrap = "allow"
+cast_sign_loss = "allow"
+cognitive_complexity = "allow"
+map_with_unused_argument_over_ranges = "warn"
+missing_const_for_fn = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+must_use_candidate = "allow"
+nursery = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+should_panic_without_expect = "allow"
+too_long_first_doc_paragraph = "allow"
+too_many_lines = "allow"

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
+#![doc = include_str!("../../README.md")]
 
 pub mod cli_ask;
 pub mod config;


### PR DESCRIPTION
The docs.rs documentation is both broken and disabled. This fixes both problems. This is useful even for things like LSP enabled editors to be able to link to documentation while working on something using the API surface. In order to also be a useful landing for end users I also included the readme (which renders pretty nicely) and because the readme is used outside of GitHub (already on crates.io for example, not docs.rc) I also added a link to the more end user facing documentation page more prominently at the top.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
