### PR TITLE
Sanitize dev-facing error and import naming code

### DIFF
--- a/daemon/integration-tests/src/actors.rs
+++ b/daemon/integration-tests/src/actors.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 use teamtype::daemon::Daemon;
 use teamtype::{document, sandbox};
 use tempfile::{TempDir, tempdir};
-use tokio::process::ChildStdin;
+use tokio::process::{ChildStdin, Command};
 
 use crate::socket::*;
 
@@ -37,7 +37,7 @@ impl Neovim {
     /// Will panic if Neovim cannot be started or if the file cannot be opened.
     pub async fn new(file_path: PathBuf) -> Self {
         let handler = Dummy::new();
-        let mut cmd = tokio::process::Command::new("nvim");
+        let mut cmd = Command::new("nvim");
         cmd.arg("--headless").arg("--embed");
         // Disable loading user RC files, to prevent unrelated local test failures
         cmd.arg("-u").arg("NORC");

--- a/daemon/src/cli_ask.rs
+++ b/daemon/src/cli_ask.rs
@@ -1,16 +1,18 @@
 // SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2025 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::io::Write;
+use std::io::{stdin, stdout};
 
 use anyhow::{Result, bail};
 
 pub fn ask(question: &str) -> Result<bool> {
     print!("{question} (y/N): ");
-    std::io::stdout().flush()?;
-    let mut lines = std::io::stdin().lines();
+    stdout().flush()?;
+    let mut lines = stdin().lines();
     if let Some(Ok(line)) = lines.next() {
         match line.to_lowercase().as_str() {
             "y" | "yes" => Ok(true),

--- a/daemon/src/cli_ask.rs
+++ b/daemon/src/cli_ask.rs
@@ -7,7 +7,8 @@
 use std::io::Write;
 use std::io::{stdin, stdout};
 
-use anyhow::{Result, bail};
+use anyhow::Result;
+use anyhow::bail;
 
 pub fn ask(question: &str) -> Result<bool> {
     print!("{question} (y/N): ");

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -8,8 +8,9 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
-use git2::ConfigLevel;
+use anyhow::bail;
+use anyhow::{Context, Result};
+use git2::{Config as GitConfig, ConfigLevel, Error as GitError, Repository};
 use ini::{Ini, Properties};
 use tracing::info;
 
@@ -278,14 +279,14 @@ fn local_git_username(base_dir: &Path) -> Result<String> {
 }
 
 fn global_git_username() -> Result<String> {
-    Ok(git2::Config::open_default()?
+    Ok(GitConfig::open_default()?
         .snapshot()?
         .get_str("user.name")?
         .to_string())
 }
 
-fn find_git_repo(path: &Path) -> Result<git2::Repository, git2::Error> {
-    git2::Repository::discover(path)
+fn find_git_repo(path: &Path) -> Result<Repository, GitError> {
+    Repository::discover(path)
 }
 
 fn add_teamtype_to_local_gitignore(directory: &Path) -> Result<()> {

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2025 zormit <nt4u@kpvn.de>
 // SPDX-FileCopyrightText: 2026 axelmartensson <axel.martensson@hotmail.com>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::iter::repeat_with;
 use std::path::{Path, PathBuf};
 use std::sync::{
     Arc,
@@ -19,9 +21,11 @@ use automerge::{
 };
 use futures::SinkExt;
 use rand::Rng;
+use tokio::sync::broadcast::error::RecvError;
 use tokio::{
     sync::{broadcast, mpsc, oneshot},
-    time::Duration,
+    time::sleep,
+    time::{Duration, Instant},
 };
 use tracing::{debug, error, info, warn};
 
@@ -516,10 +520,9 @@ impl DocumentActor {
         };
         let mut rng = rand::thread_rng();
         let options = ["d", "ü", "🥕", "💚", "\n"];
-        let random_text: String =
-            std::iter::repeat_with(|| options[rng.gen_range(0..options.len())])
-                .take(4)
-                .collect();
+        let random_text: String = repeat_with(|| options[rng.gen_range(0..options.len())])
+            .take(4)
+            .collect();
         let text_length = text.chars().count();
         let random_position = rng.gen_range(0..=text_length);
 
@@ -1022,7 +1025,7 @@ fn spawn_file_watcher(app_config: &AppConfig, document_handle: DocumentActorHand
     tokio::spawn(async move {
         let debounce_duration = Duration::from_millis(100);
 
-        let debounce_timer = tokio::time::sleep(debounce_duration);
+        let debounce_timer = sleep(debounce_duration);
         // Sleep does not implement the Unpin trait, so in order to use it with select!, we have to
         // pin it first (according to the documentation https://docs.rs/tokio/latest/tokio/time/struct.Sleep.html).
         tokio::pin!(debounce_timer);
@@ -1037,7 +1040,7 @@ fn spawn_file_watcher(app_config: &AppConfig, document_handle: DocumentActorHand
                             .send_message(DocMessage::FromWatcher(watcher_event))
                             .await;
 
-                        debounce_timer.as_mut().reset(tokio::time::Instant::now() + debounce_duration);
+                        debounce_timer.as_mut().reset(Instant::now() + debounce_duration);
                         rescan_required = true;
                     } else {
                         // Watcher terminated. Seems we're shutting down.
@@ -1067,10 +1070,10 @@ fn spawn_persister(document_handle: DocumentActorHandle) {
                 Ok(()) => {
                     // The document has changed.
                 }
-                Err(broadcast::error::RecvError::Closed) => {
+                Err(RecvError::Closed) => {
                     panic!("Doc changed channel has been closed");
                 }
-                Err(broadcast::error::RecvError::Lagged(_)) => {
+                Err(RecvError::Lagged(_)) => {
                     // This is fine, the messages in this channel are just pings.
                     // It's fine if we miss some.
                     debug!("Doc changed ping channel lagged (this is probably fine).");
@@ -1081,7 +1084,7 @@ fn spawn_persister(document_handle: DocumentActorHandle) {
 
             // Alternatively to sleeping, we could use a "back channel" in the Persist
             // message, so that the daemon tells us when it's done persisting.
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(1)).await;
         }
     });
 }

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::collections::HashMap;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
+use anyhow::{anyhow, bail};
 use automerge::{
     AutoCommit, ChangeHash, ObjType, Patch, PatchLog, ReadDoc,
     sync::{Message as AutomergeSyncMessage, State as SyncState, SyncDoc},
@@ -378,7 +380,7 @@ impl Document {
         if let Ok(Some((automerge::Value::Object(ObjType::Map), file_map))) = file_map {
             Ok(file_map)
         } else {
-            Err(anyhow::anyhow!(
+            Err(anyhow!(
                 "Automerge document doesn't have a {name} Map object"
             ))
         }
@@ -393,7 +395,7 @@ impl Document {
         if let Some((automerge::Value::Object(ObjType::Text), text_obj)) = text_obj {
             Ok(text_obj)
         } else {
-            Err(anyhow::anyhow!(
+            Err(anyhow!(
                 "Automerge document doesn't have a {file_path} Text object, so I can't provide it"
             ))
         }
@@ -414,7 +416,7 @@ impl Document {
         if let Some((automerge::Value::Object(ObjType::Text), text_obj)) = text_obj {
             Ok(text_obj)
         } else {
-            Err(anyhow::anyhow!(
+            Err(anyhow!(
                 "Automerge document doesn't have a {file_path} Text object, so I can't provide it"
             ))
         }

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use anyhow::{anyhow, bail};
 use automerge::{
     AutoCommit, ChangeHash, ObjType, Patch, PatchLog, ReadDoc,
-    sync::{Message as AutomergeSyncMessage, State as SyncState, SyncDoc},
+    sync::{Message, State, SyncDoc},
     transaction::Transactable,
 };
 use dissimilar::Chunk;
@@ -86,7 +86,7 @@ impl Document {
     pub fn receive_sync_message_log_patches(
         &mut self,
         message: AutomergeSyncMessage,
-        peer_state: &mut SyncState,
+        peer_state: &mut AutomergeSyncState,
     ) -> Vec<Patch> {
         let mut patch_log = PatchLog::active();
         self.doc
@@ -136,7 +136,7 @@ impl Document {
     #[must_use]
     pub fn generate_sync_message(
         &mut self,
-        peer_state: &mut SyncState,
+        peer_state: &mut AutomergeSyncState,
     ) -> Option<AutomergeSyncMessage> {
         self.doc.sync().generate_sync_message(peer_state)
     }
@@ -562,7 +562,7 @@ mod tests {
         #[test]
         fn test_generate_sync_message() {
             let mut document = Document::default();
-            let mut state = SyncState::new();
+            let mut state = AutomergeSyncState::new();
             assert!(document.generate_sync_message(&mut state).is_some());
             // Stops for now and waits for a response
             assert!(document.generate_sync_message(&mut state).is_none());

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -7,8 +7,8 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use anyhow::Result;
-use anyhow::{anyhow, bail};
+use anyhow::bail;
+use anyhow::{Context, Result};
 use automerge::{
     AutoCommit, ChangeHash, ObjId, ObjType, Patch, PatchLog, ReadDoc, ScalarValue, Value,
     sync::{Message as AutomergeSyncMessage, State as AutomergeSyncState, SyncDoc},
@@ -154,7 +154,7 @@ impl Document {
         let mut offset = 0isize;
 
         let Some(Content::String(text)) = self.current_file_content(file_path) else {
-            panic!("Should have initialized text before applying delta to it");
+            bail!("File {file_path} not initialized before applying delta");
         };
         // Clone so that `self` is no longer borrowed.
         let text = text.clone();
@@ -179,7 +179,7 @@ impl Document {
 
         // Update cached content.
         let Some(Content::String(old_text)) = self.files.get(file_path) else {
-            panic!("Did not find text content in files cache at file_path");
+            bail!("Did not find text content in files cache at file_path");
         };
         let new_text = delta.apply_to(old_text)?;
         self.files
@@ -361,9 +361,7 @@ impl Document {
         if let Ok(Some((Value::Object(ObjType::Map), file_map))) = file_map {
             Ok(file_map)
         } else {
-            Err(anyhow!(
-                "Automerge document doesn't have a {name} Map object"
-            ))
+            bail!("Automerge document doesn't have a {name} Map object")
         }
     }
 
@@ -372,13 +370,13 @@ impl Document {
         let text_obj = self
             .doc
             .get(file_map, file_path)
-            .unwrap_or_else(|_| panic!("Failed to get {file_path} key from Automerge document"));
+            .with_context(|| format!("Failed to get {file_path} key from Automerge document"))?;
         if let Some((Value::Object(ObjType::Text), text_obj)) = text_obj {
             Ok(text_obj)
         } else {
-            Err(anyhow!(
+            bail!(
                 "Automerge document doesn't have a {file_path} Text object, so I can't provide it"
-            ))
+            )
         }
     }
 
@@ -389,13 +387,13 @@ impl Document {
         let text_obj = self
             .doc
             .get_at(file_map, file_path, heads)
-            .unwrap_or_else(|_| panic!("Failed to get {file_path} key from Automerge document"));
+            .with_context(|| format!("Failed to get {file_path} key from Automerge document"))?;
         if let Some((Value::Object(ObjType::Text), text_obj)) = text_obj {
             Ok(text_obj)
         } else {
-            Err(anyhow!(
+            bail!(
                 "Automerge document doesn't have a {file_path} Text object, so I can't provide it"
-            ))
+            )
         }
     }
 

--- a/daemon/src/document.rs
+++ b/daemon/src/document.rs
@@ -4,13 +4,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use anyhow::Result;
 use anyhow::{anyhow, bail};
 use automerge::{
-    AutoCommit, ChangeHash, ObjType, Patch, PatchLog, ReadDoc,
-    sync::{Message, State, SyncDoc},
+    AutoCommit, ChangeHash, ObjId, ObjType, Patch, PatchLog, ReadDoc, ScalarValue, Value,
+    sync::{Message as AutomergeSyncMessage, State as AutomergeSyncState, SyncDoc},
     transaction::Transactable,
 };
 use dissimilar::Chunk;
@@ -213,18 +214,8 @@ impl Document {
         // If the content hasn't changed, don't write to the file. This prevents irrelevant watcher events.
 
         match self.doc.get_at(&file_map, file_path, heads) {
-            Ok(Some((
-                automerge::Value::Scalar(std::borrow::Cow::Owned(automerge::ScalarValue::Bytes(
-                    bytes,
-                ))),
-                _,
-            ))) => Ok(bytes),
-            Ok(Some((
-                automerge::Value::Scalar(std::borrow::Cow::Borrowed(
-                    automerge::ScalarValue::Bytes(bytes),
-                )),
-                _,
-            ))) => {
+            Ok(Some((Value::Scalar(Cow::Owned(ScalarValue::Bytes(bytes))), _))) => Ok(bytes),
+            Ok(Some((Value::Scalar(Cow::Borrowed(ScalarValue::Bytes(bytes))), _))) => {
                 // TODO: Potentially memory-heavy operation. Figure out how to deal with Cows. Moo.
                 Ok(bytes.clone())
             }
@@ -340,7 +331,7 @@ impl Document {
         if let Ok(file_map) = self.top_level_map_obj("files") {
             for file_path in self.doc.keys(&file_map) {
                 match self.doc.get(&file_map, &file_path) {
-                    Ok(Some((automerge::Value::Object(ObjType::Text), text_obj))) => {
+                    Ok(Some((Value::Object(ObjType::Text), text_obj))) => {
                         let string = self
                             .doc
                             .text(&text_obj)
@@ -348,21 +339,11 @@ impl Document {
                         self.files
                             .insert(RelativePath::new(&file_path), Content::String(string));
                     }
-                    Ok(Some((
-                        automerge::Value::Scalar(std::borrow::Cow::Owned(
-                            automerge::ScalarValue::Bytes(bytes),
-                        )),
-                        _,
-                    ))) => {
+                    Ok(Some((Value::Scalar(Cow::Owned(ScalarValue::Bytes(bytes))), _))) => {
                         self.files
                             .insert(RelativePath::new(&file_path), Content::Bytes(bytes));
                     }
-                    Ok(Some((
-                        automerge::Value::Scalar(std::borrow::Cow::Borrowed(
-                            automerge::ScalarValue::Bytes(bytes),
-                        )),
-                        _,
-                    ))) => {
+                    Ok(Some((Value::Scalar(Cow::Borrowed(ScalarValue::Bytes(bytes))), _))) => {
                         // TODO: Potentially memory-heavy operation. Figure out how to deal with Cows. Moo.
                         self.files
                             .insert(RelativePath::new(&file_path), Content::Bytes(bytes.clone()));
@@ -375,9 +356,9 @@ impl Document {
         }
     }
 
-    fn top_level_map_obj(&self, name: &str) -> Result<automerge::ObjId> {
+    fn top_level_map_obj(&self, name: &str) -> Result<ObjId> {
         let file_map = self.doc.get(automerge::ROOT, name);
-        if let Ok(Some((automerge::Value::Object(ObjType::Map), file_map))) = file_map {
+        if let Ok(Some((Value::Object(ObjType::Map), file_map))) = file_map {
             Ok(file_map)
         } else {
             Err(anyhow!(
@@ -386,13 +367,13 @@ impl Document {
         }
     }
 
-    fn text_obj(&self, file_path: &RelativePath) -> Result<automerge::ObjId> {
+    fn text_obj(&self, file_path: &RelativePath) -> Result<ObjId> {
         let file_map = self.top_level_map_obj("files")?;
         let text_obj = self
             .doc
             .get(file_map, file_path)
             .unwrap_or_else(|_| panic!("Failed to get {file_path} key from Automerge document"));
-        if let Some((automerge::Value::Object(ObjType::Text), text_obj)) = text_obj {
+        if let Some((Value::Object(ObjType::Text), text_obj)) = text_obj {
             Ok(text_obj)
         } else {
             Err(anyhow!(
@@ -401,11 +382,7 @@ impl Document {
         }
     }
 
-    fn text_obj_at(
-        &self,
-        file_path: &RelativePath,
-        heads: &[ChangeHash],
-    ) -> Result<automerge::ObjId> {
+    fn text_obj_at(&self, file_path: &RelativePath, heads: &[ChangeHash]) -> Result<ObjId> {
         // I hope this one is always there...
         let file_map = self.top_level_map_obj("files")?;
 
@@ -413,7 +390,7 @@ impl Document {
             .doc
             .get_at(file_map, file_path, heads)
             .unwrap_or_else(|_| panic!("Failed to get {file_path} key from Automerge document"));
-        if let Some((automerge::Value::Object(ObjType::Text), text_obj)) = text_obj {
+        if let Some((Value::Object(ObjType::Text), text_obj)) = text_obj {
             Ok(text_obj)
         } else {
             Err(anyhow!(

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -10,7 +10,8 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use anyhow::{Context, Result, bail};
+use anyhow::bail;
+use anyhow::{Context, Result};
 use futures::StreamExt;
 use tokio::{
     io::WriteHalf,
@@ -104,7 +105,7 @@ pub fn spawn_socket_listener(
 ) -> Result<()> {
     // Make sure the parent directory of the socket is only accessible by the current user.
     if let Err(description) = is_user_readable_only(socket_path) {
-        panic!("{}", description);
+        bail!("{description}");
     }
 
     // Using the sandbox method here is technically unnecessary,

--- a/daemon/src/editor_connection.rs
+++ b/daemon/src/editor_connection.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -264,6 +265,8 @@ impl EditorConnection {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
 
@@ -294,7 +297,7 @@ mod tests {
     fn edits_are_oted() {
         let dir = tempdir().expect("Failed to create temp directory");
         let file = dir.path().join("file");
-        std::fs::write(&file, "hello").expect("Failed to write file");
+        fs::write(&file, "hello").expect("Failed to write file");
 
         let app_config = AppConfig {
             base_dir: dir.path().to_path_buf(),

--- a/daemon/src/jsonrpc_forwarder.rs
+++ b/daemon/src/jsonrpc_forwarder.rs
@@ -16,10 +16,12 @@
 //!   "unpacked" to the socket
 
 use std::path::Path;
+use std::{process, str};
 
 use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
 use teamtype::editor::strip_current_dir;
+use tokio::io;
 use tokio::io::{AsyncRead, AsyncWrite, BufReader, BufWriter};
 use tokio::net::UnixStream;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
@@ -45,8 +47,8 @@ pub trait JSONRPCForwarder<
         let (mut socket_read, mut socket_write) = self.connect_stream(base_dir).await?;
 
         // Construct stdin/stdout objects, which send/receive messages with a Content-Length header.
-        let mut stdin = FramedRead::new(BufReader::new(tokio::io::stdin()), ContentLengthCodec);
-        let mut stdout = FramedWrite::new(BufWriter::new(tokio::io::stdout()), ContentLengthCodec);
+        let mut stdin = FramedRead::new(BufReader::new(io::stdin()), ContentLengthCodec);
+        let mut stdout = FramedWrite::new(BufWriter::new(io::stdout()), ContentLengthCodec);
 
         tokio::spawn(async move {
             while let Some(Ok(message)) = socket_read.next().await {
@@ -56,14 +58,14 @@ pub trait JSONRPCForwarder<
                     .expect("Failed to write to stdout");
             }
             // Socket was closed.
-            std::process::exit(0);
+            process::exit(0);
         });
 
         while let Some(Ok(message)) = stdin.next().await {
             socket_write.send(message).await?;
         }
         // Stdin was closed.
-        std::process::exit(0);
+        process::exit(0);
     }
 }
 
@@ -135,7 +137,7 @@ impl Decoder for ContentLengthCodec {
         };
 
         // Parse the content length.
-        let content_length = std::str::from_utf8(
+        let content_length = str::from_utf8(
             &src[start_of_header + c.len()..start_of_header + c.len() + end_of_line],
         )?
         .parse()?;
@@ -152,6 +154,6 @@ impl Decoder for ContentLengthCodec {
         // Return the body of the message.
         src.advance(content_start);
         let content = src.split_to(content_length);
-        Ok(Some(std::str::from_utf8(&content)?.to_string()))
+        Ok(Some(str::from_utf8(&content)?.to_string()))
     }
 }

--- a/daemon/src/logging.rs
+++ b/daemon/src/logging.rs
@@ -1,15 +1,19 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::env;
 
 use anyhow::Result;
 use time::macros::format_description;
 use tracing::level_filters::LevelFilter;
+use tracing::subscriber;
 use tracing_subscriber::{EnvFilter, FmtSubscriber, fmt::time::UtcTime};
 
 pub fn initialize() -> Result<()> {
-    let simplified_logging = std::env::var("RUST_LOG").is_err();
+    let simplified_logging = env::var("RUST_LOG").is_err();
 
     if simplified_logging {
         let subscriber = FmtSubscriber::builder()
@@ -18,9 +22,7 @@ pub fn initialize() -> Result<()> {
             .with_level(false)
             .with_target(false)
             .finish();
-
-        tracing::subscriber::set_global_default(subscriber)
-            .expect("Setting default log subscriber failed");
+        subscriber::set_global_default(subscriber).expect("Setting default log subscriber failed");
     } else {
         let timer = UtcTime::new(format_description!("[hour]:[minute]:[second]Z"));
         let filter = EnvFilter::builder()
@@ -31,9 +33,7 @@ pub fn initialize() -> Result<()> {
             .with_thread_ids(true)
             .with_timer(timer)
             .finish();
-
-        tracing::subscriber::set_global_default(subscriber)
-            .expect("Setting default log subscriber failed");
+        subscriber::set_global_default(subscriber).expect("Setting default log subscriber failed");
     }
 
     Ok(())

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -5,8 +5,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::env;
 use std::path::{Path, PathBuf};
+use std::process::exit;
+use std::{env, panic};
 
 use anyhow::{Context, Result, bail};
 use clap::{CommandFactory as _, FromArgMatches as _};
@@ -43,10 +44,10 @@ fn has_teamtype_directory(dir: &Path) -> bool {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let default_panic = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
+    let default_panic = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
         default_panic(info);
-        std::process::exit(1);
+        exit(1);
     }));
 
     let arg_matches = Cli::command().get_matches();

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -9,7 +9,8 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::{env, panic};
 
-use anyhow::{Context, Result, bail};
+use anyhow::bail;
+use anyhow::{Context, Result};
 use clap::{CommandFactory as _, FromArgMatches as _};
 use microxdg::XdgApp;
 use teamtype::{

--- a/daemon/src/ot.rs
+++ b/daemon/src/ot.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -500,7 +501,7 @@ mod tests {
     }
 
     mod operational_transform_internals {
-        use operational_transform::Operation as OTOperation;
+        use operational_transform::Operation;
 
         use super::*;
 
@@ -589,15 +590,15 @@ mod tests {
                 .expect("Transform failed. Do the lengths fit?");
             assert_eq!(
                 a_prime.ops(),
-                vec![OTOperation::Retain(1), OTOperation::Insert("x".to_string())]
+                vec![Operation::Retain(1), Operation::Insert("x".to_string())]
             );
             assert_eq!(
                 b_prime.ops(),
                 vec![
-                    OTOperation::Retain(1),
-                    OTOperation::Delete(1),
-                    OTOperation::Retain(1),
-                    OTOperation::Delete(1)
+                    Operation::Retain(1),
+                    Operation::Delete(1),
+                    Operation::Retain(1),
+                    Operation::Delete(1)
                 ]
             );
 
@@ -610,17 +611,17 @@ mod tests {
             assert_eq!(
                 a_prime.ops(),
                 vec![
-                    OTOperation::Retain(2),
-                    OTOperation::Insert("x".to_string()),
-                    OTOperation::Retain(2)
+                    Operation::Retain(2),
+                    Operation::Insert("x".to_string()),
+                    Operation::Retain(2)
                 ]
             );
             assert_eq!(
                 c_prime.ops(),
                 vec![
-                    OTOperation::Retain(3),
-                    OTOperation::Insert("y".to_string()),
-                    OTOperation::Retain(1)
+                    Operation::Retain(3),
+                    Operation::Insert("y".to_string()),
+                    Operation::Retain(1)
                 ]
             );
         }

--- a/daemon/src/path.rs
+++ b/daemon/src/path.rs
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::path::{self, Path, PathBuf};
 
-use anyhow::{Context, bail};
+use anyhow::Context;
+use anyhow::bail;
 use automerge::Prop;
 use derive_more::{AsRef, Deref, Display};
 use serde::{Deserialize, Serialize};

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -13,7 +13,8 @@ use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
+use anyhow::bail;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use iroh::discovery::dns::DnsDiscovery;
 use iroh::discovery::pkarr::PkarrPublisher;

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -16,9 +17,10 @@ use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use iroh::discovery::dns::DnsDiscovery;
 use iroh::discovery::pkarr::PkarrPublisher;
-use iroh::endpoint::{Connection as IrohEndpointConnection, RecvStream, SendStream};
+use iroh::endpoint::{Connection as IrohEndpointConnection, RecvStream, RelayMode, SendStream};
 use iroh::{Endpoint, NodeAddr, PublicKey, RelayMap, RelayUrl, SecretKey};
 use postcard::{from_bytes, to_allocvec};
+use rand::rngs::OsRng;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
@@ -46,7 +48,7 @@ impl FromStr for SecretAddress {
             bail!("Peer string must have format <node_id>#<passphrase>");
         }
 
-        let node_addr = iroh::PublicKey::from_str(parts[0])?.into();
+        let node_addr = PublicKey::from_str(parts[0])?.into();
         let passphrase = SecretKey::from_str(parts[1])?;
 
         Ok(Self {
@@ -119,17 +121,17 @@ impl ConnectionManager {
     async fn build_endpoint(
         app_config: &AppConfig,
         base_dir: &Path,
-    ) -> Result<(iroh::Endpoint, SecretKey)> {
+    ) -> Result<(Endpoint, SecretKey)> {
         let (secret_key, my_passphrase) = Self::get_keypair(base_dir);
 
-        let mut builder = iroh::Endpoint::builder()
+        let mut builder = Endpoint::builder()
             .secret_key(secret_key)
             .alpns(vec![ALPN.to_vec()]);
 
         if let Some(iroh_relay) = &app_config.iroh_relay {
             let relay_url = RelayUrl::from_str(iroh_relay)?;
             let relay_map = RelayMap::from(relay_url);
-            builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(relay_map));
+            builder = builder.relay_mode(RelayMode::Custom(relay_map));
         }
 
         if let Some(iroh_dns_domain) = &app_config.iroh_dns_domain {
@@ -193,8 +195,8 @@ impl ConnectionManager {
             )
         } else {
             debug!("Generating new keypair.");
-            let secret_key = SecretKey::generate(rand::rngs::OsRng);
-            let passphrase = SecretKey::generate(rand::rngs::OsRng);
+            let secret_key = SecretKey::generate(OsRng);
+            let passphrase = SecretKey::generate(OsRng);
 
             let mut file = OpenOptions::new()
                 .create_new(true)
@@ -229,7 +231,7 @@ enum EndpointMessage {
 // Owns the Iroh endpoint, accepts incoming connections, and can be instructed to connect to
 // another daemon.
 struct EndpointActor {
-    endpoint: iroh::Endpoint,
+    endpoint: Endpoint,
     message_rx: mpsc::Receiver<EndpointMessage>,
     message_tx: mpsc::Sender<EndpointMessage>,
     document_handle: DocumentActorHandle,
@@ -238,7 +240,7 @@ struct EndpointActor {
 
 impl EndpointActor {
     fn new(
-        endpoint: iroh::Endpoint,
+        endpoint: Endpoint,
         message_rx: mpsc::Receiver<EndpointMessage>,
         message_tx: mpsc::Sender<EndpointMessage>,
         document_handle: DocumentActorHandle,

--- a/daemon/src/peer.rs
+++ b/daemon/src/peer.rs
@@ -16,8 +16,8 @@ use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use iroh::discovery::dns::DnsDiscovery;
 use iroh::discovery::pkarr::PkarrPublisher;
-use iroh::endpoint::{RecvStream, SendStream};
-use iroh::{NodeAddr, RelayMap, RelayUrl, SecretKey};
+use iroh::endpoint::{Connection as IrohEndpointConnection, RecvStream, SendStream};
+use iroh::{Endpoint, NodeAddr, PublicKey, RelayMap, RelayUrl, SecretKey};
 use postcard::{from_bytes, to_allocvec};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
@@ -374,7 +374,7 @@ impl EndpointActor {
         }
     }
 
-    fn handle_incoming_connection(&self, conn: iroh::endpoint::Connection) {
+    fn handle_incoming_connection(&self, conn: IrohEndpointConnection) {
         let node_id = conn
             .remote_node_id()
             .expect("Connection should have a node ID");
@@ -400,23 +400,23 @@ impl EndpointActor {
 
     async fn handle_peer(
         document_handle: DocumentActorHandle,
-        conn: iroh::endpoint::Connection,
+        conn: IrohEndpointConnection,
         auth: PeerAuth,
     ) -> Result<()> {
-        let connection = IrohConnection::new(conn, auth).await?;
-        let syncer = SyncActor::new(document_handle, Box::new(connection));
+        let stream = PeerMessageStream::new(conn, auth).await?;
+        let syncer = SyncActor::new(document_handle, Box::new(stream));
         syncer.run().await
     }
 }
 
-// Sends/receives PeerMessages to/from and Iroh connection.
-struct IrohConnection {
+// Sends/receives PeerMessages through an Iroh connection.
+struct PeerMessageStream {
     send: SendStream,
     message_rx: mpsc::Receiver<Result<PeerMessage>>,
 }
 
-impl IrohConnection {
-    async fn new(conn: iroh::endpoint::Connection, auth: PeerAuth) -> Result<Self> {
+impl PeerMessageStream {
+    async fn new(conn: IrohEndpointConnection, auth: PeerAuth) -> Result<Self> {
         let (send, receive) = match auth {
             PeerAuth::YourPassphrase(passphrase) => {
                 let (mut send, recv) = conn.open_bi().await?;
@@ -473,7 +473,7 @@ impl IrohConnection {
 }
 
 #[async_trait]
-impl Connection<PeerMessage> for IrohConnection {
+impl Connection<PeerMessage> for PeerMessageStream {
     async fn send(&mut self, message: PeerMessage) -> Result<()> {
         let bytes: Vec<u8> =
             to_allocvec(&message).context("Failed to convert PeerMessage to bytes")?;

--- a/daemon/src/peer/sync.rs
+++ b/daemon/src/peer/sync.rs
@@ -7,7 +7,7 @@ use std::mem;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use automerge::sync::{Message as AutomergeSyncMessage, State as SyncState};
+use automerge::sync::{Message as AutomergeSyncMessage, State as AutomergeSyncState};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, oneshot};
 use tracing::debug;
@@ -35,7 +35,7 @@ pub trait Connection<T>: Send + Sync {
 /// Exchanges [`PeerMessage`]s with the connection, and communicates with the document on the other side.
 /// Maintains the sync state.
 pub struct SyncActor {
-    peer_state: SyncState,
+    peer_state: AutomergeSyncState,
     document_handle: DocumentActorHandle,
     connection: Box<dyn Connection<PeerMessage>>,
 }
@@ -46,7 +46,7 @@ impl SyncActor {
         connection: Box<dyn Connection<PeerMessage>>,
     ) -> Self {
         Self {
-            peer_state: SyncState::new(),
+            peer_state: AutomergeSyncState::new(),
             document_handle,
             connection,
         }

--- a/daemon/src/peer/sync.rs
+++ b/daemon/src/peer/sync.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2025 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -9,7 +10,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use automerge::sync::{Message as AutomergeSyncMessage, State as AutomergeSyncState};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{broadcast, oneshot};
+use tokio::sync::{broadcast::error::RecvError, oneshot};
 use tracing::debug;
 
 use crate::daemon::{DocMessage, DocumentActorHandle};
@@ -114,10 +115,10 @@ impl SyncActor {
                 doc_ping = doc_changed_ping_rx.recv() => {
                     match doc_ping {
                         Ok(()) => { self.generate_sync_message().await?; }
-                        Err(broadcast::error::RecvError::Closed) => {
+                        Err(RecvError::Closed) => {
                             panic!("Doc changed channel has been closed");
                         }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                        Err(RecvError::Lagged(_)) => {
                             // This is fine, the messages in this channel are just pings.
                             // It's fine if we miss some.
                             debug!("Doc changed ping channel lagged (this is probably fine).");
@@ -129,10 +130,10 @@ impl SyncActor {
                         Ok(ephemeral_message) => {
                             self.connection.send(PeerMessage::Ephemeral(ephemeral_message)).await?;
                         }
-                        Err(broadcast::error::RecvError::Closed) => {
+                        Err(RecvError::Closed) => {
                             panic!("Ephemeral message channel has been closed");
                         }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                        Err(RecvError::Lagged(_)) => {
                             // We missed some cursor states, because of the limited
                             // capacity of the channel.
                             debug!("Ephemeral message channel lagged (this is unfortunate, but okay).");

--- a/daemon/src/sandbox.rs
+++ b/daemon/src/sandbox.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
 // SPDX-FileCopyrightText: 2026 axelmartensson <axel.martensson@hotmail.com>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -11,7 +12,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use ignore::WalkBuilder;
@@ -214,7 +215,7 @@ fn absolute_and_canonicalized(path: &Path) -> Result<PathBuf> {
             break;
         }
         prefix_path.pop();
-        if let std::path::Component::Normal(os_str) = component {
+        if let Component::Normal(os_str) = component {
             suffix_path = if suffix_path.components().count() != 0 {
                 Path::new(os_str).join(&suffix_path)
             } else {
@@ -238,6 +239,8 @@ fn absolute_and_canonicalized(path: &Path) -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::symlink;
+
     use tempfile::{TempDir, tempdir};
 
     use super::*;
@@ -264,7 +267,7 @@ mod tests {
         let dir = temp_dir_setup();
         let linked_project = dir.path().join("ln_project");
         let project = dir.path().join("project");
-        std::os::unix::fs::symlink(&project, &linked_project).unwrap();
+        symlink(&project, &linked_project).unwrap();
         assert_eq!(
             absolute_and_canonicalized(&linked_project).unwrap(),
             project.canonicalize().unwrap()
@@ -276,7 +279,7 @@ mod tests {
         let dir = temp_dir_setup();
         let linked_project = dir.path().join("ln_project");
         let project = dir.path().join("project");
-        std::os::unix::fs::symlink(&project, &linked_project).unwrap();
+        symlink(&project, &linked_project).unwrap();
 
         let ln_file = linked_project.join("c");
 
@@ -291,7 +294,7 @@ mod tests {
         let dir = temp_dir_setup();
         let linked_project = dir.path().join("ln_project");
         let project = dir.path().join("project");
-        std::os::unix::fs::symlink(&project, &linked_project).unwrap();
+        symlink(&project, &linked_project).unwrap();
 
         let file = project.join("a");
         let ln_file = linked_project.join("a");

--- a/daemon/src/sandbox.rs
+++ b/daemon/src/sandbox.rs
@@ -14,7 +14,8 @@ use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::bail;
+use anyhow::{Context, Result};
 use ignore::WalkBuilder;
 use ignore::overrides::OverrideBuilder;
 use path_clean::PathClean;
@@ -222,7 +223,7 @@ fn absolute_and_canonicalized(path: &Path) -> Result<PathBuf> {
                 Path::new(os_str).to_path_buf()
             };
         } else {
-            panic!("Got unexpected Component variant while canonicalizing");
+            bail!("Got unexpected Component variant while canonicalizing");
         }
     }
 

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -4,11 +4,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::fmt;
+use std::borrow::Cow;
+use std::{fmt, vec};
 
 use anyhow::{Context, Error, Result};
 use anyhow::{anyhow, bail};
-use automerge::{ConcreteTextValue, Patch, PatchAction, TextEncoding};
+use automerge::{
+    ConcreteTextValue, ObjId, ObjType, Patch, PatchAction, Prop, ScalarValue, TextEncoding, Value,
+};
 use dissimilar::Chunk;
 use operational_transform::{Operation, OperationSeq};
 use ropey::Rope;
@@ -61,7 +64,7 @@ impl TextDelta {
 }
 
 impl IntoIterator for TextDelta {
-    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type IntoIter = vec::IntoIter<Self::Item>;
     type Item = TextOp;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -90,7 +93,7 @@ impl fmt::Display for TextOp {
 pub struct EditorTextDelta(pub Vec<EditorTextOp>);
 
 impl IntoIterator for EditorTextDelta {
-    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type IntoIter = vec::IntoIter<Self::Item>;
     type Item = EditorTextOp;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -341,16 +344,14 @@ impl TryFrom<&Patch> for PatchEffect {
     type Error = Error;
 
     fn try_from(patch: &Patch) -> Result<Self, Self::Error> {
-        fn file_path_from_path_default(
-            path: &[(automerge::ObjId, automerge::Prop)],
-        ) -> Result<RelativePath, Error> {
+        fn file_path_from_path_default(path: &[(ObjId, Prop)]) -> Result<RelativePath, Error> {
             if path.len() != 2 {
                 return Err(anyhow!(
                     "Unexpected path in Automerge patch, length is not 2"
                 ));
             }
             let (_obj_id, prop) = &path[1];
-            if let automerge::Prop::Map(file_path) = prop {
+            if let Prop::Map(file_path) = prop {
                 return Ok(RelativePath::new(file_path));
             }
             Err(anyhow!(
@@ -376,7 +377,7 @@ impl TryFrom<&Patch> for PatchEffect {
         }
 
         match &patch.path[0] {
-            (_, automerge::Prop::Map(key)) if key == "files" => {
+            (_, Prop::Map(key)) if key == "files" => {
                 if patch.path.len() == 1 {
                     match &patch.action {
                         PatchAction::PutMap {
@@ -389,7 +390,7 @@ impl TryFrom<&Patch> for PatchEffect {
                             let relative_path = RelativePath::new(key);
 
                             match value {
-                                (automerge::Value::Object(automerge::ObjType::Text), _) => {
+                                (Value::Object(ObjType::Text), _) => {
                                     if *conflict {
                                         // In this case, the peer receiving this PutMap should
                                         // remove all existing content of this file in open
@@ -407,12 +408,9 @@ impl TryFrom<&Patch> for PatchEffect {
                                         )))
                                     }
                                 }
-                                (
-                                    automerge::Value::Scalar(std::borrow::Cow::Owned(
-                                        automerge::ScalarValue::Bytes(bytes),
-                                    )),
-                                    _,
-                                ) => Ok(Self::FileBytes(relative_path, bytes.clone())),
+                                (Value::Scalar(Cow::Owned(ScalarValue::Bytes(bytes))), _) => {
+                                    Ok(Self::FileBytes(relative_path, bytes.clone()))
+                                }
                                 _ => Err(anyhow!("Unexpected value in path {relative_path}")),
                             }
                         }
@@ -424,7 +422,7 @@ impl TryFrom<&Patch> for PatchEffect {
                         PatchAction::Conflict { prop } => {
                             // This can happen when both sides create the same file.
                             match prop {
-                                automerge::Prop::Map(file_name) => {
+                                Prop::Map(file_name) => {
                                     // We assume that conflict resolution works the way, that the
                                     // side that gets the PatchAction is the one that "wins".
                                     warn!(
@@ -432,7 +430,7 @@ impl TryFrom<&Patch> for PatchEffect {
                                     );
                                     Ok(Self::NoEffect)
                                 }
-                                automerge::Prop::Seq(seq) => Err(anyhow!(
+                                Prop::Seq(seq) => Err(anyhow!(
                                     "Got a Seq-type prop as a conflict, expected Map: {seq}"
                                 )),
                             }

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Error, Result};
 use anyhow::{anyhow, bail};
 use automerge::{ConcreteTextValue, Patch, PatchAction, TextEncoding};
 use dissimilar::Chunk;
-use operational_transform::{Operation as OTOperation, OperationSeq};
+use operational_transform::{Operation, OperationSeq};
 use ropey::Rope;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
@@ -512,13 +512,13 @@ impl From<OperationSeq> for TextDelta {
         let mut delta = Self::default();
         for op in op_seq.ops() {
             match op {
-                OTOperation::Retain(n) => {
+                Operation::Retain(n) => {
                     delta.retain(*n as usize);
                 }
-                OTOperation::Insert(s) => {
+                Operation::Insert(s) => {
                     delta.insert(s);
                 }
-                OTOperation::Delete(n) => {
+                Operation::Delete(n) => {
                     delta.delete(*n as usize);
                 }
             }

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -7,8 +7,8 @@
 use std::borrow::Cow;
 use std::{fmt, vec};
 
+use anyhow::bail;
 use anyhow::{Context, Error, Result};
-use anyhow::{anyhow, bail};
 use automerge::{
     ConcreteTextValue, ObjId, ObjType, Patch, PatchAction, Prop, ScalarValue, TextEncoding, Value,
 };
@@ -346,17 +346,13 @@ impl TryFrom<&Patch> for PatchEffect {
     fn try_from(patch: &Patch) -> Result<Self, Self::Error> {
         fn file_path_from_path_default(path: &[(ObjId, Prop)]) -> Result<RelativePath, Error> {
             if path.len() != 2 {
-                return Err(anyhow!(
-                    "Unexpected path in Automerge patch, length is not 2"
-                ));
+                bail!("Unexpected path in Automerge patch, length is not 2");
             }
             let (_obj_id, prop) = &path[1];
             if let Prop::Map(file_path) = prop {
                 return Ok(RelativePath::new(file_path));
             }
-            Err(anyhow!(
-                "Unexpected path in Automerge patch: Prop is not a map"
-            ))
+            bail!("Unexpected path in Automerge patch: Prop is not a map")
         }
 
         if patch.path.is_empty() {
@@ -365,14 +361,10 @@ impl TryFrom<&Patch> for PatchEffect {
                     if key == "files" {
                         Ok(Self::NoEffect)
                     } else {
-                        Err(anyhow!(
-                            "Path is empty and action is PutMap, but key is not 'files'",
-                        ))
+                        bail!("Path is empty and action is PutMap, but key is not 'files'")
                     }
                 }
-                other_action => Err(anyhow!(
-                    "Unsupported patch action for empty path: {other_action}"
-                )),
+                other_action => bail!("Unsupported patch action for empty path: {other_action}"),
             };
         }
 
@@ -411,7 +403,7 @@ impl TryFrom<&Patch> for PatchEffect {
                                 (Value::Scalar(Cow::Owned(ScalarValue::Bytes(bytes))), _) => {
                                     Ok(Self::FileBytes(relative_path, bytes.clone()))
                                 }
-                                _ => Err(anyhow!("Unexpected value in path {relative_path}")),
+                                _ => bail!("Unexpected value in path {relative_path}"),
                             }
                         }
                         PatchAction::DeleteMap { key } => {
@@ -430,14 +422,14 @@ impl TryFrom<&Patch> for PatchEffect {
                                     );
                                     Ok(Self::NoEffect)
                                 }
-                                Prop::Seq(seq) => Err(anyhow!(
-                                    "Got a Seq-type prop as a conflict, expected Map: {seq}"
-                                )),
+                                Prop::Seq(seq) => {
+                                    bail!("Got a Seq-type prop as a conflict, expected Map: {seq}")
+                                }
                             }
                         }
-                        other_action => Err(anyhow!(
-                            "Unsupported patch action for path 'files': {other_action}"
-                        )),
+                        other_action => {
+                            bail!("Unsupported patch action for path 'files': {other_action}")
+                        }
                     }
                 } else if patch.path.len() == 2 {
                     let mut delta = TextDelta::default();
@@ -458,19 +450,19 @@ impl TryFrom<&Patch> for PatchEffect {
                                 delta,
                             )))
                         }
-                        other_action => Err(anyhow!(
-                            "Unsupported patch action for path 'files/*': {other_action}"
-                        )),
+                        other_action => {
+                            bail!("Unsupported patch action for path 'files/*': {other_action}")
+                        }
                     }
                 } else {
-                    Err(anyhow!(
+                    bail!(
                         "Unexpected path action for path 'files/**', expected it to be of length 1 or 2"
-                    ))
+                    )
                 }
             }
-            (_, _) => Err(anyhow!(
-                "Unexpected path in Automerge patch, expected it to begin with 'files'"
-            )),
+            (_, _) => {
+                bail!("Unexpected path in Automerge patch, expected it to begin with 'files'")
+            }
         }
     }
 }

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::fmt;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Error, Result};
+use anyhow::{anyhow, bail};
 use automerge::{ConcreteTextValue, Patch, PatchAction, TextEncoding};
 use dissimilar::Chunk;
 use operational_transform::{Operation as OTOperation, OperationSeq};
@@ -336,14 +338,14 @@ impl TextDelta {
 // TODO: This feels like it should go into another file, close to where Document handles writing to
 // the Automerge document. Both places need to know about our chosen structure.
 impl TryFrom<&Patch> for PatchEffect {
-    type Error = anyhow::Error;
+    type Error = Error;
 
     fn try_from(patch: &Patch) -> Result<Self, Self::Error> {
         fn file_path_from_path_default(
             path: &[(automerge::ObjId, automerge::Prop)],
-        ) -> Result<RelativePath, anyhow::Error> {
+        ) -> Result<RelativePath, Error> {
             if path.len() != 2 {
-                return Err(anyhow::anyhow!(
+                return Err(anyhow!(
                     "Unexpected path in Automerge patch, length is not 2"
                 ));
             }
@@ -351,7 +353,7 @@ impl TryFrom<&Patch> for PatchEffect {
             if let automerge::Prop::Map(file_path) = prop {
                 return Ok(RelativePath::new(file_path));
             }
-            Err(anyhow::anyhow!(
+            Err(anyhow!(
                 "Unexpected path in Automerge patch: Prop is not a map"
             ))
         }
@@ -362,12 +364,12 @@ impl TryFrom<&Patch> for PatchEffect {
                     if key == "files" {
                         Ok(Self::NoEffect)
                     } else {
-                        Err(anyhow::anyhow!(
+                        Err(anyhow!(
                             "Path is empty and action is PutMap, but key is not 'files'",
                         ))
                     }
                 }
-                other_action => Err(anyhow::anyhow!(
+                other_action => Err(anyhow!(
                     "Unsupported patch action for empty path: {other_action}"
                 )),
             };
@@ -411,9 +413,7 @@ impl TryFrom<&Patch> for PatchEffect {
                                     )),
                                     _,
                                 ) => Ok(Self::FileBytes(relative_path, bytes.clone())),
-                                _ => {
-                                    Err(anyhow::anyhow!("Unexpected value in path {relative_path}"))
-                                }
+                                _ => Err(anyhow!("Unexpected value in path {relative_path}")),
                             }
                         }
                         PatchAction::DeleteMap { key } => {
@@ -432,12 +432,12 @@ impl TryFrom<&Patch> for PatchEffect {
                                     );
                                     Ok(Self::NoEffect)
                                 }
-                                automerge::Prop::Seq(seq) => Err(anyhow::anyhow!(
+                                automerge::Prop::Seq(seq) => Err(anyhow!(
                                     "Got a Seq-type prop as a conflict, expected Map: {seq}"
                                 )),
                             }
                         }
-                        other_action => Err(anyhow::anyhow!(
+                        other_action => Err(anyhow!(
                             "Unsupported patch action for path 'files': {other_action}"
                         )),
                     }
@@ -460,17 +460,17 @@ impl TryFrom<&Patch> for PatchEffect {
                                 delta,
                             )))
                         }
-                        other_action => Err(anyhow::anyhow!(
+                        other_action => Err(anyhow!(
                             "Unsupported patch action for path 'files/*': {other_action}"
                         )),
                     }
                 } else {
-                    Err(anyhow::anyhow!(
+                    Err(anyhow!(
                         "Unexpected path action for path 'files/**', expected it to be of length 1 or 2"
                     ))
                 }
             }
-            (_, _) => Err(anyhow::anyhow!(
+            (_, _) => Err(anyhow!(
                 "Unexpected path in Automerge patch, expected it to begin with 'files'"
             )),
         }

--- a/daemon/src/watcher.rs
+++ b/daemon/src/watcher.rs
@@ -4,15 +4,17 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::future::pending;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     time::{Duration, SystemTime},
 };
 
+use futures::executor;
 use notify::{
-    RecommendedWatcher, RecursiveMode, Result as NotifyResult, Watcher as NotifyWatcher,
-    event::EventKind,
+    Event, RecommendedWatcher, RecursiveMode, Result as NotifyResult, Watcher as NotifyWatcher,
+    event::{CreateKind, EventKind, ModifyKind, RemoveKind, RenameMode},
 };
 use tokio::{
     sync::mpsc::{self, Receiver, Sender},
@@ -45,7 +47,7 @@ struct PendingEvent {
 pub struct Watcher {
     _inner: RecommendedWatcher,
     app_config: AppConfig,
-    notify_receiver: Receiver<NotifyResult<notify::Event>>,
+    notify_receiver: Receiver<NotifyResult<Event>>,
     event_tx: Sender<WatcherEvent>,
     pending_events: HashMap<PathBuf, PendingEvent>,
 }
@@ -55,8 +57,8 @@ impl Watcher {
         let (event_tx, event_rx) = mpsc::channel(1);
 
         let (tx, rx) = mpsc::channel(1);
-        let mut watcher = notify::recommended_watcher(move |res: NotifyResult<notify::Event>| {
-            futures::executor::block_on(async {
+        let mut watcher = notify::recommended_watcher(move |res: NotifyResult<Event>| {
+            executor::block_on(async {
                 tx.send(res)
                     .await
                     .expect("Unable to send over mpsc channel from file watcher");
@@ -101,20 +103,20 @@ impl Watcher {
                     // TODO: Better errors?
                     let event = event.unwrap().unwrap();
                     match event.kind {
-                        EventKind::Create(notify::event::CreateKind::File) => {
+                        EventKind::Create(CreateKind::File) => {
                             assert!(event.paths.len() == 1);
                             self.maybe_created(&event.paths[0]);
                         }
-                        EventKind::Remove(notify::event::RemoveKind::File) => {
+                        EventKind::Remove(RemoveKind::File) => {
                             assert!(event.paths.len() == 1);
                             self.maybe_removed(&event.paths[0]);
                         }
-                        EventKind::Modify(notify::event::ModifyKind::Data(_)) => {
+                        EventKind::Modify(ModifyKind::Data(_)) => {
                             assert!(event.paths.len() == 1);
                             self.maybe_modified(&event.paths[0]);
                         }
-                        EventKind::Modify(notify::event::ModifyKind::Name(
-                            notify::event::RenameMode::Both,
+                        EventKind::Modify(ModifyKind::Name(
+                            RenameMode::Both,
                         )) => {
                             assert!(event.paths.len() == 2);
                             self.maybe_removed(&event.paths[0]);
@@ -122,8 +124,8 @@ impl Watcher {
                         }
                         // MacOS doesn't give us details on moving a file, so we need to infer what
                         // happened.
-                        EventKind::Modify(notify::event::ModifyKind::Name(
-                            notify::event::RenameMode::Any,
+                        EventKind::Modify(ModifyKind::Name(
+                            RenameMode::Any,
                         )) => {
                             assert!(event.paths.len() == 1);
                             let file_path = event.paths[0].clone();
@@ -187,7 +189,7 @@ impl Watcher {
             event
         } else {
             // Await forever.
-            std::future::pending::<WatcherEvent>().await
+            pending::<WatcherEvent>().await
         }
     }
 


### PR DESCRIPTION
This comes out of some paper-cuts I got while sorting through the existing code. This shouldn't change *much*. There will be some slight differences in backtraces because there is a difference between directly panicing in a deep function and raising an error that causes a panic higher up, but the additional context information from each layer that errors do successfully propagate should be a good thing. Other than that difference this should all just be develope facing code readability improvements. There are certainly some subjective calls here becuase there is more than one way to skin a cat. I started with points that caught my attention like:

- 'it makes no sense to `use tokio::time::Duration` and thereafter refer to `Duration` but in the same file refer to `tokio::time::Instant`' and
- 'aliasing documented types from other crates when they don't even conflict with anything just makes it hard to reference the appropriate docs'

and expanded the concept to try to make the import/call verbosity balance as consistent as I could without changing any public interfaces or getting into the weeds where actual ambiguity would result.

These commits are best reviewed one by one, combining them makes it hard to see *why* a change is made.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
