### PR TITLE
Fix integration tests to not load user's Neovim config

### DIFF
--- a/daemon/integration-tests/src/actors.rs
+++ b/daemon/integration-tests/src/actors.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -38,6 +39,8 @@ impl Neovim {
         let handler = Dummy::new();
         let mut cmd = tokio::process::Command::new("nvim");
         cmd.arg("--headless").arg("--embed");
+        // Disable loading user RC files, to prevent unrelated local test failures
+        cmd.arg("-u").arg("NORC");
         // Disable ShaDa files, to prevent CI failures related to them.
         cmd.arg("-i").arg("NONE");
         // Disable Swap file, to prevent CI failures related to them.


### PR DESCRIPTION
Here's an easy one. I've been unable to test locally even when CI was passing. This is why ;-)

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
