### PR TITLE
Avoid 'path must be shorter than SUN_LEN' when sharing long winded paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # 0.9.2 (unreleased)
 
+Fix issue blocking directories that are deeply nested (or have very long winded names) from being shared.
+
 Handle POSIX specific process signalling without assuming everybody is running a Unix platform.
 
 Fix CLI thread handling to correctly listen for SIGINT (<Ctrl>-C) and SIGTERM (typically invoked with `kill`) while the main daemon or client loop is running.

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -1,11 +1,14 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! This module is all about daemon to editor communication.
 
-use std::{fs, os::unix::fs::PermissionsExt, path::Path};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
 
 use anyhow::{Context, Result, bail};
 use futures::StreamExt;
@@ -82,6 +85,14 @@ fn is_user_readable_only(socket_path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn strip_current_dir(path: &Path) -> PathBuf {
+    let Ok(cwd) = env::current_dir() else {
+        return path.to_path_buf();
+    };
+    path.strip_prefix(&cwd)
+        .map_or_else(|_| path.to_path_buf(), Path::to_path_buf)
+}
+
 /// # Panics
 ///
 /// Will panic if we fail to listen on the socket, or if we fail to accept an incoming connection.
@@ -111,7 +122,11 @@ pub fn spawn_socket_listener(
         }
     }
 
-    let listener = UnixListener::bind(socket_path)?;
+    // The std library function used to create sockets requires a path shorter than SUN_LEN, but the
+    // length that matters is only the segment it is asked to handle. If passed an absolute path
+    // here we can potentially be run in a path that exceeds the maximum (~100 chars). Passing it a
+    // relative path effectively sidesteps this limitation.
+    let listener = UnixListener::bind(strip_current_dir(socket_path))?;
     debug!("Listening on UNIX socket: {}", socket_path.display());
 
     tokio::spawn(async move {

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -85,7 +85,9 @@ fn is_user_readable_only(socket_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn strip_current_dir(path: &Path) -> PathBuf {
+// Private use, should be pub(crate) but is currently used in both bin and lib crates
+#[doc(hidden)]
+pub fn strip_current_dir(path: &Path) -> PathBuf {
     let Ok(cwd) = env::current_dir() else {
         return path.to_path_buf();
     };

--- a/daemon/src/jsonrpc_forwarder.rs
+++ b/daemon/src/jsonrpc_forwarder.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
+use teamtype::editor::strip_current_dir;
 use tokio::io::{AsyncRead, AsyncWrite, BufReader, BufWriter};
 use tokio::net::UnixStream;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
@@ -79,7 +80,12 @@ impl JSONRPCForwarder<OwnedReadHalf, OwnedWriteHalf> for UnixJSONRPCForwarder {
     )> {
         // Construct socket object, which send/receive newline-delimited messages.
         let socket_path = directory.join(CONFIG_DIR).join(DEFAULT_SOCKET_NAME);
-        let stream = UnixStream::connect(socket_path).await?;
+        // See comment about SUN_LEN in editor.rs, but the TL;DR is that referencing a socket node
+        // from a deeply nested or overly verbose path will fail on some platforms. The calling
+        // context should already have changed to the target directory (if any), so stripping it
+        // here will result in a relative path that won't have a cumbersomely long prefix that fails
+        // safety checks.
+        let stream = UnixStream::connect(strip_current_dir(&socket_path)).await?;
         let (socket_read, socket_write) = stream.into_split();
         let socket_read = FramedRead::new(socket_read, LinesCodec::new());
         let socket_write = FramedWrite::new(socket_write, LinesCodec::new());

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -5,6 +5,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::env;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -182,6 +183,10 @@ async fn run_daemon(cli: Cli, directory: PathBuf) -> Result<Daemon> {
 }
 
 async fn run_client(directory: PathBuf) -> Result<()> {
+    // See comment in editor, but the TL;DR is that referencing a socket node from a deeply
+    // nested or overly verbose path will fail on some platforms. By *changing* into the
+    // target directory first we enable the use of relative paths in socket creation calls.
+    env::set_current_dir(&directory)?;
     let jsonrpc_forwarder = jsonrpc_forwarder::UnixJSONRPCForwarder {};
     jsonrpc_forwarder
         .connection(&directory)
@@ -338,5 +343,5 @@ fn setup_teamtype_directory(directory: &Path, temporary_directory: Option<&TempD
 }
 
 fn get_current_directory() -> Result<PathBuf> {
-    std::env::current_dir().context("Could not access current directory")
+    env::current_dir().context("Could not access current directory")
 }


### PR DESCRIPTION
Closes #462

(This is a repost of #536 which I accidentally opened as a PR from my fork’s default branch.)

**Self-review checklist**

- [x] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
