### PR TITLE
Fix client shut down and daemon startup

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -40,12 +40,6 @@ fn has_teamtype_directory(dir: &Path) -> bool {
     sandbox::exists(dir, &teamtype_dir).expect("Failed to check") && teamtype_dir.is_dir()
 }
 
-#[derive(PartialEq)]
-enum MainMode {
-    Daemon,
-    Client,
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     let default_panic = std::panic::take_hook();
@@ -67,26 +61,13 @@ async fn main() -> Result<()> {
     setup_teamtype_directory(&directory, temporary_directory.as_ref())
         .context("Failed to find .teamtype/ directory")?;
 
-    let mode = match cli.command {
-        Commands::Share { .. } | Commands::Join { .. } => MainMode::Daemon,
-        Commands::Client => MainMode::Client,
-    };
-
-    let (shutdown_tx, mut shutdown_rx) = tokio::sync::broadcast::channel(1);
-
-    tokio::select! {
-        _ = run_daemon(cli, directory.clone()), if mode == MainMode::Daemon => {}
-        _ = run_client(directory.clone()), if mode == MainMode::Client => {}
-        _ = shutdown_rx.recv() => {}
+    match cli.command {
+        Commands::Share { .. } | Commands::Join { .. } => run_daemon(cli, directory.clone()).await,
+        Commands::Client => run_client(directory.clone()).await,
     }
-
-    trap_shutdown().await;
-    let _ = shutdown_tx.send(());
-
-    Ok(())
 }
 
-async fn run_daemon(cli: Cli, directory: PathBuf) -> Result<Daemon> {
+async fn run_daemon(cli: Cli, directory: PathBuf) -> Result<()> {
     let persist = !config::has_git_remote(&directory);
     if !persist {
         // TODO: drop .teamtype/doc here? Would that be rude?
@@ -183,8 +164,15 @@ async fn run_daemon(cli: Cli, directory: PathBuf) -> Result<Daemon> {
 
     debug!("Starting Teamtype on {}.", app_config.base_dir.display());
 
-    let daemon = Daemon::new(app_config, init_doc, persist);
-    daemon.await.context("Failed to launch the daemon")
+    // Start the daemon. It will do its work in background processes and return a handle to it.
+    let _daemon = Daemon::new(app_config, init_doc, persist)
+        .await
+        .context("Failed to launch the daemon")?;
+
+    // Then, wait for an external shutdown signal.
+    trap_shutdown().await;
+
+    Ok(())
 }
 
 async fn run_client(directory: PathBuf) -> Result<()> {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -61,13 +61,22 @@ async fn main() -> Result<()> {
     setup_teamtype_directory(&directory, temporary_directory.as_ref())
         .context("Failed to find .teamtype/ directory")?;
 
-    match cli.command {
+    // TODO: If the result of this joined future handle were to go out of scope and hence be
+    // dropped, *some* but not all parts of the daemon would shut down. Notably the local socket
+    // will go away but the remote networking connections would stay up! This is a fundamental issue
+    // with the daemon module and merits refactoring so the long running socket and network
+    // listeners properly listen to the mpsc channel or receive and process a cancellation token.
+    let _handle = match cli.command {
         Commands::Share { .. } | Commands::Join { .. } => run_daemon(cli, directory.clone()).await,
-        Commands::Client => run_client(directory.clone()).await,
-    }
+        Commands::Client => return run_client(directory.clone()).await,
+    };
+
+    trap_shutdown().await;
+
+    Ok(())
 }
 
-async fn run_daemon(cli: Cli, directory: PathBuf) -> Result<()> {
+async fn run_daemon(cli: Cli, directory: PathBuf) -> Result<Daemon> {
     let persist = !config::has_git_remote(&directory);
     if !persist {
         // TODO: drop .teamtype/doc here? Would that be rude?
@@ -152,7 +161,7 @@ async fn run_daemon(cli: Cli, directory: PathBuf) -> Result<()> {
                 .context("Failed to resolve peer")?;
         }
         Commands::Client => {
-            panic!("This can't happen, as we earlier matched on Share|Join.")
+            unreachable!("This can't happen, as we earlier matched on Share|Join.")
         }
     }
 
@@ -164,15 +173,12 @@ async fn run_daemon(cli: Cli, directory: PathBuf) -> Result<()> {
 
     debug!("Starting Teamtype on {}.", app_config.base_dir.display());
 
-    // Start the daemon. It will do its work in background processes and return a handle to it.
-    let _daemon = Daemon::new(app_config, init_doc, persist)
+    // Setup a new daemon from the derived config. Immediately join the handle because that's what
+    // actually starts the local socket and any configured network connections. Return the result
+    // so the calling context can determine when to terminate.
+    Daemon::new(app_config, init_doc, persist)
         .await
-        .context("Failed to launch the daemon")?;
-
-    // Then, wait for an external shutdown signal.
-    trap_shutdown().await;
-
-    Ok(())
+        .context("Failed to launch the daemon")
 }
 
 async fn run_client(directory: PathBuf) -> Result<()> {

--- a/daemon/src/watcher.rs
+++ b/daemon/src/watcher.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -56,7 +57,9 @@ impl Watcher {
         let (tx, rx) = mpsc::channel(1);
         let mut watcher = notify::recommended_watcher(move |res: NotifyResult<notify::Event>| {
             futures::executor::block_on(async {
-                tx.send(res).await.unwrap();
+                tx.send(res)
+                    .await
+                    .expect("Unable to send over mpsc channel from file watcher");
             });
         })
         .expect("Could not construct watcher");


### PR DESCRIPTION
We introduced a problem in #533: `teamtype client` wouldn't shut down on its own after errors, for example, not being able to connect to the daemon's socket. 

run_daemon returned a handle to the daemon, but the daemon is doing its work in other threads/tasks. So we want to wait for an external shutdown signal after calling it.

run_client, on the other hand, returns only when it errors. The returned Result should determine the exit code of the main program. We don't want an additional shutdown capture after that. `teamtype client` doesn't need to do any cleanup, so going with the default behaviour where shutdown signals just kill the process seems fine - we don't need to set up the shutdown trap ourselves.

After restructuring this, it seemed to me that the Mode enum was no longer needed and I removed it again.

I added a couple of comments to help future readers understand this. The different behaviour of the two modes is a tad confusing, but I'd rather push a quick fix now and possibly tackle this in a future "proper shutdown" PR.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [-] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
