### PR TITLE
Fixup e2e tests to leave user's plugin environment behind

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -56,10 +56,6 @@ jobs:
           neovim: true
           version: ${{ matrix.nvim-version }}
       - run: nvim --version
-      - name: Install Neovim plugin
-        run: |
-          mkdir -p $HOME/.local/share/nvim/site/pack/plugins/start
-          ln -s $PWD/../nvim-plugin $HOME/.local/share/nvim/site/pack/plugins/start/teamtype
       - name: Compile unit tests
         run: cargo test --no-default-features --no-run --locked
       - name: Run unit tests

--- a/daemon/integration-tests/.cargo/config.toml
+++ b/daemon/integration-tests/.cargo/config.toml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+[env]
+CARGO_WORKSPACE_DIR = { value = "../../", relative = true }

--- a/daemon/integration-tests/src/actors.rs
+++ b/daemon/integration-tests/src/actors.rs
@@ -27,7 +27,7 @@ pub trait Actor: Send {
 }
 
 pub struct Neovim {
-    nvim: nvim_rs::Neovim<Compat<ChildStdin>>,
+    pub nvim: nvim_rs::Neovim<Compat<ChildStdin>>,
     buffer: nvim_rs::Buffer<Compat<ChildStdin>>,
 }
 
@@ -35,24 +35,35 @@ impl Neovim {
     /// # Panics
     ///
     /// Will panic if Neovim cannot be started or if the file cannot be opened.
-    pub async fn new(file_path: PathBuf) -> Self {
+    pub async fn new(file_path: Option<PathBuf>) -> Self {
         let handler = Dummy::new();
         let mut cmd = Command::new("nvim");
-        cmd.arg("--headless").arg("--embed");
-        // Disable loading user RC files, to prevent unrelated local test failures
-        cmd.arg("-u").arg("NORC");
-        // Disable ShaDa files, to prevent CI failures related to them.
-        cmd.arg("-i").arg("NONE");
-        // Disable Swap file, to prevent CI failures related to them.
+        cmd.arg("--headless");
+        cmd.arg("--embed");
+        // Use factory defaults, disable user config, plugins, and shada.
+        cmd.arg("--clean");
+        // Also disable fallback from shada to swap files.
         cmd.arg("-n");
+        // Add the local Neovim plugin tree to the plugin path.
+        let workspace_root = PathBuf::from(env!("CARGO_WORKSPACE_DIR"));
+        let workspace_root = workspace_root.to_string_lossy();
+        cmd.arg("-c").arg(format!(
+            r#"let &runtimepath="{workspace_root}/nvim-plugin,".&runtimepath"#
+        ));
+        // Load the Neovim plugin into the instance.
+        cmd.arg("-c").arg(format!(
+            "source {workspace_root}/nvim-plugin/plugin/teamtype.lua"
+        ));
         let (nvim, _, _) = new_child_cmd(&mut cmd, handler).await.unwrap();
 
         // We canonicalize the path here, because on macOS, TempDir gives us paths in /var/, which
         // symlinks to /private/var/. But the paths in the file events are always in /private/var/.
-        let file_path = file_path.canonicalize().unwrap();
-        nvim.command(&format!("edit! {}", file_path.display()))
-            .await
-            .expect("Opening file in nvim failed");
+        if let Some(file_path) = file_path {
+            let file_path = file_path.canonicalize().unwrap();
+            nvim.command(&format!("edit! {}", file_path.display()))
+                .await
+                .expect("Opening file in nvim failed");
+        }
 
         let buffer = nvim.get_current_buf().await.unwrap();
 
@@ -195,7 +206,7 @@ impl Neovim {
         let socket = MockSocket::new(&socket_path);
 
         (
-            Self::new(canonicalized_file_path.clone()).await,
+            Self::new(Some(canonicalized_file_path.clone())).await,
             canonicalized_file_path,
             socket,
             dir,

--- a/daemon/integration-tests/tests/fuzzer.rs
+++ b/daemon/integration-tests/tests/fuzzer.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<()> {
     // Wait until iroh's DNS discovery (hopefully) works.
     sleep(Duration::from_millis(1000)).await;
 
-    let nvim = Neovim::new(file).await;
+    let nvim = Neovim::new(Some(file)).await;
 
     let mut app_config2 = AppConfig::default();
     app_config2.base_dir = dir2.path().to_path_buf();
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
         sleep(Duration::from_millis(100)).await;
     }
 
-    let nvim2 = Neovim::new(file2).await;
+    let nvim2 = Neovim::new(Some(file2)).await;
 
     // Give the second Neovim time to process the "open" call.
     sleep(Duration::from_millis(1000)).await;

--- a/daemon/integration-tests/tests/nvim-plugin.rs
+++ b/daemon/integration-tests/tests/nvim-plugin.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -17,10 +18,7 @@ use tokio::time::{Duration, timeout};
 
 #[tokio::test]
 async fn plugin_loaded() {
-    let handler = Dummy::new();
-    let mut cmd = tokio::process::Command::new("nvim");
-    cmd.arg("--headless").arg("--embed");
-    let (nvim, _, _) = new_child_cmd(&mut cmd, handler).await.unwrap();
+    let nvim = Neovim::new(None).await.nvim;
     nvim.command("TeamtypeInfo")
         .await
         .expect("Failed to run TeamtypeInfo");
@@ -28,10 +26,7 @@ async fn plugin_loaded() {
 
 #[tokio::test]
 async fn teamtype_executable_from_nvim() {
-    let handler = Dummy::new();
-    let mut cmd = tokio::process::Command::new("nvim");
-    cmd.arg("--headless").arg("--embed");
-    let (nvim, _, _) = new_child_cmd(&mut cmd, handler).await.unwrap();
+    let nvim = Neovim::new(None).await.nvim;
     assert_eq!(
         nvim.command_output("echomsg executable('teamtype')")
             .await


### PR DESCRIPTION
My previous PR #535 was onto something but [didn't go far enough](https://github.com/teamtype/teamtype/pull/535#issuecomment-4400820934). It turns out running tests locally really wasn't isolated at all.

Draft mode for the moment because this still needs a way to have the plugin as tested use the binaries as built at time of testing, not just a random system one that the dev may or may not have just built and installed in the `$PATH` to match. That's happening in CI right now, but not necessarily locally. That part *might* have to wait for my workspace fixes in #543 that get the testing into the same workspace as the bin & lib crates, but I'll at least look into whether it is viable to fix here first.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
