### PR TITLE
Fixup e2e tests to use test build's binary, not $PATH

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,5 +2,12 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+# This is the default, but forcing it here makes sure the e2e tests can find it
+# relative to the workspace dir env we're also setting even in the event users
+# have customized Cargo's default target directory, e.g. to use shared artifacts.
+[build]
+target-dir = "target"
+
 [env]
 CARGO_WORKSPACE_DIR = { value = "", relative = true }
+TEAMTYPE_DEBUG_BINARY = { value = "target/debug/teamtype", relative = true }

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -38,13 +38,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: Build Teamtype
-        run: cargo build --release
       - name: Install Neovim
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
           version: ${{ matrix.nvim-version }}
+      - name: Build Teamtype
+        run: cargo build --profile test
       - run: nvim --version
       - name: Compile default tests
         run: cargo test --locked --no-default-features --no-run

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -40,9 +40,6 @@ jobs:
           cache-on-failure: true
       - name: Build Teamtype
         run: cargo build --release
-      - name: Add teamtype binary to PATH
-        run: echo "$PWD/target/release" >> $GITHUB_PATH
-      - run: teamtype --version
       - name: Install Neovim
         uses: rhysd/action-setup-vim@v1
         with:

--- a/Justfile
+++ b/Justfile
@@ -25,6 +25,18 @@ set unstable
 
 profile := "dev"
 
+# With positional arguments enabled, we can pass all the arguments to the bash
+# shell in a way that will get expanded to the original 'word' breakdown. However,
+# when we do this blindly in all cases and the job's positional arguments happen
+# to be empty the shell decides we must have wanted a placeholder for an empty
+# string argument — a construct that is invalid for many of our commands. The
+# solution is to decide up front whether we have any positional arguments at all
+# and then either not pass anything or pass them in a way that will get expanded
+# properly. As a caveat we can't use this workaround for nested jobs that pass
+# positional arguments to other jobs since one layer of quoting is lost, but we
+# don't need to because none of those happen to use spaces in arguments anyway.
+maybe-pass(args) := if args != "" { '"$@"' } else { "" }
+
 [group('check')]
 [parallel]
 check *ARGS: (check-cargo ARGS) check-typos
@@ -123,12 +135,13 @@ perfect: check lint test fuzz
 #     alias nvim='just --justfile ~/path/to/teamtype/Justfile nvim'
 #
 # Run Neovim with the plug-in for testing (can be used from outside the project).
+[script]
 [no-cd]
 nvim *ARGS: build-test
     {{ nvim }} --clean \
         --cmd {{ quote("let &runtimepath=\"" + justfile_directory() + "/nvim-plugin,\" . &runtimepath") }} \
         --cmd 'runtime plugin/teamtype.lua' \
-        {{ ARGS }}
+        {{ maybe-pass(ARGS) }}
 
 # This task will build (if necessary) and run the Teamtype CLI via the development version from this repository.
 # This is especially useful for manual testing and can be used from anywhere by invoking the Justfile externally,
@@ -137,6 +150,7 @@ nvim *ARGS: build-test
 #     alias teamtype='just --justfile ~/path/to/teamtype/Justfile teamtype'
 #
 # Build and run Teamtype for testing (can be used from outside the project).
+[script]
 [no-cd]
 teamtype *ARGS: build-test
-    $TEAMTYPE_BINARY {{ ARGS }}
+    $TEAMTYPE_BINARY {{ maybe-pass(ARGS) }}

--- a/Justfile
+++ b/Justfile
@@ -21,6 +21,8 @@ set shell := ['bash', '-eu', '-c']
 set positional-arguments
 set unstable
 
+profile := "dev"
+
 [group('check')]
 [parallel]
 check *ARGS: (check-cargo ARGS) check-typos
@@ -40,10 +42,11 @@ check-typos:
 
 [group('build')]
 build *ARGS:
-    {{ cargo }} build {{ ARGS }}
+    {{ cargo }} build --profile {{ profile }} {{ ARGS }}
 
 [group('build')]
-build-release: (build "--release")
+build-release *ARGS:
+    {{ just }} --set profile release build {{ ARGS }}
 
 [group('format')]
 [parallel]

--- a/Justfile
+++ b/Justfile
@@ -11,6 +11,8 @@ reuse := require('reuse')
 stylua := require('stylua')
 typos := require('typos')
 
+export TEAMTYPE_BINARY := justfile_directory() + "/target/debug/teamtype"
+
 # By default Just will re-use the user's $SHELL. In order to make use of script
 # rules and more advanced shell features we need a more predictable runtime
 # environment. This setup is a little more strict than the default shell options
@@ -47,6 +49,10 @@ build *ARGS:
 [group('build')]
 build-release *ARGS:
     {{ just }} --set profile release build {{ ARGS }}
+
+[group('build')]
+build-test *ARGS:
+    {{ just }} --set profile test build {{ ARGS }}
 
 [group('format')]
 [parallel]
@@ -99,18 +105,18 @@ lint-rust:
 test *ARGS: (test-cargo ARGS)
 
 [group('test')]
-test-cargo *ARGS:
+test-cargo *ARGS: build
     {{ cargo }} test {{ ARGS }}
 
 [group('test')]
-fuzz:
+fuzz: build
     {{ cargo }} test --test fuzzer
 
 # Verify all the things: check, lint, test, and fuzz.
 [parallel]
 perfect: check lint test fuzz
 
-# This task will run Neovim with factory settings plus the development version of the plug-in from this repository.
+# This task will run Neovim with factory settings but wired to the development version of the client from this repository.
 # This is especially useful for manual testing and can be used from anywhere by invoking the Justfile externally,
 # e.g. with an alias such as:
 #
@@ -118,8 +124,19 @@ perfect: check lint test fuzz
 #
 # Run Neovim with the plug-in for testing (can be used from outside the project).
 [no-cd]
-nvim *ARGS:
+nvim *ARGS: build-test
     {{ nvim }} --clean \
         --cmd {{ quote("let &runtimepath=\"" + justfile_directory() + "/nvim-plugin,\" . &runtimepath") }} \
         --cmd 'runtime plugin/teamtype.lua' \
         {{ ARGS }}
+
+# This task will build (if necessary) and run the Teamtype CLI via the development version from this repository.
+# This is especially useful for manual testing and can be used from anywhere by invoking the Justfile externally,
+# e.g. with an alias such as:
+#
+#     alias teamtype='just --justfile ~/path/to/teamtype/Justfile teamtype'
+#
+# Build and run Teamtype for testing (can be used from outside the project).
+[no-cd]
+teamtype *ARGS: build-test
+    $TEAMTYPE_BINARY {{ ARGS }}

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -44,6 +44,7 @@ futures.workspace = true
 pretty_assertions.workspace = true
 serial_test = "3"
 tracing.workspace = true
+teamtype.workspace = true
 
 [lints]
 workspace = true

--- a/crates/e2e-tests/src/actors.rs
+++ b/crates/e2e-tests/src/actors.rs
@@ -18,6 +18,10 @@ use tokio::process::{ChildStdin, Command};
 
 use crate::socket::MockSocket;
 
+// This is the bin artifact Cargo is building for us so we can test the actual code at the time of
+// testing, not something that may be mix-matched from the system path.
+pub const TEAMTYPE_DEBUG_BINARY: &str = env!("TEAMTYPE_DEBUG_BINARY");
+
 // TODO: Consider renaming this, to avoid confusion with tokio "actors".
 #[async_trait]
 pub trait Actor: Send {
@@ -37,6 +41,10 @@ impl Neovim {
     ///
     /// Will panic if Neovim cannot be started or if the file cannot be opened.
     pub async fn new(file_path: Option<PathBuf>) -> Self {
+        assert!(
+            fs::exists(TEAMTYPE_DEBUG_BINARY).unwrap(),
+            "Before running e2e tests you must build {TEAMTYPE_DEBUG_BINARY}"
+        );
         let handler = Dummy::new();
         let mut cmd = Command::new("nvim");
         cmd.arg("--headless");
@@ -55,6 +63,8 @@ impl Neovim {
         cmd.arg("-c").arg(format!(
             "source {workspace_root}/nvim-plugin/plugin/teamtype.lua"
         ));
+        // Use binary built for *this* test run, not the system path one
+        cmd.env("TEAMTYPE_BINARY", TEAMTYPE_DEBUG_BINARY);
         let (nvim, _, _) = new_child_cmd(&mut cmd, handler).await.unwrap();
 
         // We canonicalize the path here, because on macOS, TempDir gives us paths in /var/, which

--- a/crates/e2e-tests/tests/nvim-plugin.rs
+++ b/crates/e2e-tests/tests/nvim-plugin.rs
@@ -28,7 +28,7 @@ async fn plugin_loaded() {
 async fn teamtype_executable_from_nvim() {
     let nvim = Neovim::new(None).await.nvim;
     assert_eq!(
-        nvim.command_output("echomsg executable('teamtype')")
+        nvim.command_output(format!("echomsg executable('{TEAMTYPE_DEBUG_BINARY}')").as_str())
             .await
             .expect("Failed to run executable() in Neovim"),
         "1",

--- a/nvim-plugin/plugin/teamtype.lua
+++ b/nvim-plugin/plugin/teamtype.lua
@@ -1,12 +1,17 @@
 -- SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
 -- SPDX-FileCopyrightText: 2025 zormit <nt4u@kpvn.de>
+-- SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 --
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
 local teamtype = require("teamtype")
 
+-- Enable testing or using a teamtype binary outside of the path without
+-- creating a dedicated config file for it. Used in e2e testing.
+local binary_name = os.getenv("TEAMTYPE_BINARY") or "teamtype"
+
 teamtype.config("teamtype", {
-    cmd = { "teamtype", "client" },
+    cmd = { binary_name, "client" },
     root_markers = ".teamtype",
 })
 


### PR DESCRIPTION
Follow up to #544 (and #535 before that) to use the binaries built for this test run, not whatever is in the user's `$PATH` at the time of the test run. This helps local tests to be isolated from the user's environment.

Per [this comment](https://github.com/teamtype/teamtype/pull/544#issuecomment-4401614773) this is split into a draft PR because it uses nightly features and I want to research what our options are for avoiding that.

**Self-review checklist**

- [x] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
