### PR TITLE
Fix socket creation for additional use case where share --directory is deeply nested

### DIFF
--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -958,15 +958,15 @@ impl Daemon {
 
         let document_handle = DocumentActorHandle::new(&app_config, init, is_host, persist);
 
+        let base_dir = &app_config.base_dir;
+
         // Start socket listener.
-        let socket_path = app_config
-            .base_dir
+        let socket_path = base_dir
             .join(config::CONFIG_DIR)
             .join(config::DEFAULT_SOCKET_NAME);
         editor::spawn_socket_listener(&socket_path, document_handle.clone())?;
 
         // Start file watcher.
-        let base_dir = app_config.base_dir.clone();
         spawn_file_watcher(&app_config, document_handle.clone());
 
         if persist {
@@ -976,7 +976,7 @@ impl Daemon {
 
         // Start connection manager.
         let connection_manager =
-            peer::ConnectionManager::new(&app_config, document_handle.clone(), &base_dir)
+            peer::ConnectionManager::new(&app_config, document_handle.clone(), base_dir)
                 .await
                 .expect("Failed to start connection manager");
         let address = connection_manager.secret_address();

--- a/daemon/src/editor.rs
+++ b/daemon/src/editor.rs
@@ -128,8 +128,19 @@ pub fn spawn_socket_listener(
     // The std library function used to create sockets requires a path shorter than SUN_LEN, but the
     // length that matters is only the segment it is asked to handle. If passed an absolute path
     // here we can potentially be run in a path that exceeds the maximum (~100 chars). Passing it a
-    // relative path effectively sidesteps this limitation.
+    // relative path effectively sidesteps this limitation. Stripping the leading path segments will
+    // result in a relative path that won't have a long cumbersome prefix that fails safety checks.
+    // The extra song and dance to change into the parent directory first is not needed by our CLI
+    // (which already changes to that location) but it will make this API usable when linked as a
+    // library without changing the parent thread's location for keeps.
+    let previous_cwd = env::current_dir()?;
+    env::set_current_dir(
+        socket_path
+            .parent()
+            .context("Invalid socket creation location")?,
+    )?;
     let listener = UnixListener::bind(strip_current_dir(socket_path))?;
+    env::set_current_dir(previous_cwd)?;
     debug!("Listening on UNIX socket: {}", socket_path.display());
 
     tokio::spawn(async move {

--- a/daemon/src/jsonrpc_forwarder.rs
+++ b/daemon/src/jsonrpc_forwarder.rs
@@ -16,8 +16,9 @@
 //!   "unpacked" to the socket
 
 use std::path::Path;
-use std::{process, str};
+use std::{env, process, str};
 
+use anyhow::Context;
 use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
 use teamtype::editor::strip_current_dir;
@@ -83,11 +84,18 @@ impl JSONRPCForwarder<OwnedReadHalf, OwnedWriteHalf> for UnixJSONRPCForwarder {
         // Construct socket object, which send/receive newline-delimited messages.
         let socket_path = directory.join(CONFIG_DIR).join(DEFAULT_SOCKET_NAME);
         // See comment about SUN_LEN in editor.rs, but the TL;DR is that referencing a socket node
-        // from a deeply nested or overly verbose path will fail on some platforms. The calling
-        // context should already have changed to the target directory (if any), so stripping it
-        // here will result in a relative path that won't have a cumbersomely long prefix that fails
-        // safety checks.
+        // from a deeply nested or overly verbose path will fail on some platforms.
+        // The extra song and dance to change into the parent directory first is not needed by our CLI
+        // (which already changes to that location) but it will make this API usable when linked as a
+        // library without changing the parent thread's location for keeps.
+        let previous_cwd = env::current_dir()?;
+        env::set_current_dir(
+            socket_path
+                .parent()
+                .context("Invalid socket creation location")?,
+        )?;
         let stream = UnixStream::connect(strip_current_dir(&socket_path)).await?;
+        env::set_current_dir(previous_cwd)?;
         let (socket_read, socket_write) = stream.into_split();
         let socket_read = FramedRead::new(socket_read, LinesCodec::new());
         let socket_write = FramedWrite::new(socket_write, LinesCodec::new());

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -191,10 +191,6 @@ fn parse_share_config(command: Commands, directory: PathBuf) -> AppConfig {
 }
 
 async fn run_client(directory: PathBuf) -> Result<()> {
-    // See comment in editor, but the TL;DR is that referencing a socket node from a deeply
-    // nested or overly verbose path will fail on some platforms. By *changing* into the
-    // target directory first we enable the use of relative paths in socket creation calls.
-    env::set_current_dir(&directory)?;
     let jsonrpc_forwarder = jsonrpc_forwarder::UnixJSONRPCForwarder {};
     jsonrpc_forwarder
         .connection(&directory)


### PR DESCRIPTION
PR #537 did not go quite far enough fixing #462. We caught the issue for socket creation from share/join when in the target directory and for the client even when using an extrenal `--directory`, but I did not catch the case of using `--directory` with the share subcommand.

This should catch that by just changing the whole CLI context –which should be good for other reasons too– but also adds a workaround directly to the call sites so that future use as a linked library will also function and not mess up the parent thread's location in the process.

**Self-review checklist**

- [x] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
