### PR TITLE
Update status of known advisories

### DIFF
--- a/daemon/deny.toml
+++ b/daemon/deny.toml
@@ -24,7 +24,8 @@ ignore = [
     "RUSTSEC-2026-0119", # cpu exhaustion: hickory-proto (via iroh)
 ]
 
-# Not exhaustive, just whitelist the current dependency tree
+# This is not an exhaustive list of licenses we could accept, it is just
+# a whitelist of licenses currently known to be in the dependency tree.
 [licenses]
 allow = [
     "AGPL-3.0-or-later",
@@ -41,6 +42,6 @@ allow = [
     "Zlib",
 ]
 exceptions = [
-    # only AGPL compatible because it has the necessary extra clause
+    # This instance is only AGPL compatible because it has the necessary extra clause.
     { allow = ["EUPL-1.2"], crate = "magic-wormhole" },
 ]

--- a/daemon/deny.toml
+++ b/daemon/deny.toml
@@ -19,6 +19,9 @@ ignore = [
     "RUSTSEC-2026-0097", # unsound: rand (via iroh)
     "RUSTSEC-2026-0098", # vulnerable: rustls-webpki (via iroh)
     "RUSTSEC-2026-0099", # vulnerable: rustls-webpki (via iroh)
+    "RUSTSEC-2026-0104", # reachable panic: rustls-webpki (via iroh)
+    "RUSTSEC-2026-0118", # unbounded loop: hickory-proto (via iroh)
+    "RUSTSEC-2026-0119", # cpu exhaustion: hickory-proto (via iroh)
 ]
 
 # Not exhaustive, just whitelist the current dependency tree

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -214,7 +214,7 @@ async fn trap_shutdown() {
     };
 
     #[cfg(not(unix))]
-    let temination = std::future::pending::<()>();
+    let termination = std::future::pending::<()>();
 
     tokio::select! {
         () = interruption => {


### PR DESCRIPTION
The recent features we added using new Iroh dependencies surfaced a couple more advisories. These shouldn't be a security risk for us, and will be resolved when we can eventually bump Iroh.

Although I do have `cargo-deny` checks locally I wasn't paying attention to to them when #523 merged, and they are not yet in CI either. Given that they were introduced to our SBOM in that PR, these should have been added there along with the lock file bump, but we overlooked that. Of course I had to bump into these on another branch where I have the tooling set to run automatically. Eventually this will be checked without having to remember specifically! Thankfully nothing serious for our security model.

**Self-review checklist**

- [x] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
