### PR TITLE
Add developer-facing local tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,23 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # 0.9.2 (unreleased)
 
-Fix issue blocking directories that are deeply nested (or have very long winded names) from being shared.
+Fix issue blocking directories with deep nesting (or very long winded names) from being shared.
 
 Handle POSIX specific process signalling without assuming everybody is running a Unix platform.
 
-Fix CLI thread handling to correctly listen for SIGINT (<Ctrl>-C) and SIGTERM (typically invoked with `kill`) while the main daemon or client loop is running.
+Fix CLI thread handling to correctly listen for `SIGINT` (<kbd>Ctrl</kbd>-<kbd>C</kbd>) and `SIGTERM` (typically generated with `kill`) while the main daemon or client loop is running.
 
 Add support for JSON-RPC IDs in string to be compliant with the [JSON-RPC specification](https://www.jsonrpc.org/specification).
 
-Add support for `.teamtypeignore` file to exclude files and directories from synchronization. The syntax is similar to `.gitignore`, supporting file names, directories, and glob patterns.
+Add support for a `.teamtypeignore` file to exclude files and directories from synchronization. The syntax is similar to `.gitignore`, supporting file names, directories, and glob patterns.
 
 Add support for custom Iroh relay servers, using the `--iroh-relay` flag, and for custom Iroh DNS discovery servers, using `--iroh-dns-domain` and `--iroh-pkarr-relay`. See the "Running your own relays" page in the documentation for how to run all these relays yourself!
 
 ## Notes for package maintainers
 
-### Renamed the Linux binaries
+### Renamed binary release assets
 
-We've renamed the Linux binaries
+We've renamed the prebuilt Linux binaries
 - `teamtype-x86_64-unknown-linux-musl` to `teamtype-x86_64-linux-static`
 - `teamtype-aarch64-unknown-linux-musl` to `teamtype-aarch64-linux-static`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,19 @@ too_many_lines = "allow"
 [workspace.lints.rust]
 unsafe_code = "forbid"
 unused_qualifications = "warn"
+
+[workspace.metadata.typos.default]
+locale = "en-us"
+extend-words = {
+    ot = "ot"
+}
+extend-ignore-identifiers-re = [
+    "2nd",
+]
+extend-ignore-re = [
+    # Ignore the line following a comment containing typos:ignore-next-line.
+    "(#|//|--)\\s*typos:ignore-next-line\\n.*",
+]
+
+[workspace.metadata.typos.files]
+extend-exclude = ["/docs/decisions/*.md", "CHANGELOG.md"]

--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,7 @@ just := just_executable()
 luacheck := require('luacheck')
 reuse := require('reuse')
 stylua := require('stylua')
+typos := require('typos')
 
 # By default Just will re-use the user's $SHELL. In order to make use of script
 # rules and more advanced shell features we need a more predictable runtime
@@ -19,10 +20,14 @@ set shell := ['bash', '-eu', '-c']
 set positional-arguments
 set unstable
 
-check: check-cargo
+[parallel]
+check: check-cargo check-typos
 
 check-cargo:
     {{ cargo }} check
+
+check-typos:
+    {{ typos }}
 
 [default]
 [private]

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,7 @@ cargo := require('cargo')
 cargo-deny := require('cargo-deny')
 just := just_executable()
 luacheck := require('luacheck')
+nvim := require('nvim')
 reuse := require('reuse')
 stylua := require('stylua')
 typos := require('typos')
@@ -86,3 +87,17 @@ fuzz:
 # Verify all the things: check, lint, test, and fuzz.
 [parallel]
 perfect: check lint test fuzz
+
+# This task will run Neovim with factory settings plus the development version of the plug-in from this repository.
+# This is especially useful for manual testing and can be used from anywhere by invoking the Justfile externally,
+# e.g. with an alias such as:
+#
+#     alias nvim='just --justfile ~/path/to/teamtype/Justfile nvim'
+#
+# Run Neovim with the plug-in for testing (can be used from outside the project).
+[no-cd]
+nvim *ARGS:
+    {{ nvim }} --clean \
+        --cmd {{ quote("let &runtimepath=\"" + justfile_directory() + "/nvim-plugin,\" . &runtimepath") }} \
+        --cmd 'runtime plugin/teamtype.lua' \
+        {{ ARGS }}

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+cargo := require('cargo')
+cargo-deny := require('cargo-deny')
+just := just_executable()
+luacheck := require('luacheck')
+reuse := require('reuse')
+stylua := require('stylua')
+
+# By default Just will re-use the user's $SHELL. In order to make use of script
+# rules and more advanced shell features we need a more predictable runtime
+# environment. This setup is a little more strict than the default shell options
+# to make sure we abort if a command in the middle of a job fails, etc.
+set script-interpreter := ['bash', '-eu']
+set shell := ['bash', '-eu', '-c']
+
+set positional-arguments
+set unstable
+
+check: check-cargo
+
+check-cargo:
+    {{ cargo }} check
+
+[default]
+[private]
+@list:
+    {{ just }} --list --unsorted
+
+build *ARGS:
+    {{ cargo }} build {{ ARGS }}
+
+build-release: (build "--release")
+
+[parallel]
+format: format-lua format-rust
+
+[working-directory("nvim-plugin")]
+format-lua:
+    {{ stylua }} --respect-ignores .
+
+format-rust:
+    {{ cargo }} +nightly fmt
+
+[parallel]
+lint: lint-format lint-license lint-lua lint-manifests lint-rust
+
+[parallel]
+lint-format: lint-format-lua lint-format-rust
+
+[working-directory("nvim-plugin")]
+lint-format-lua:
+    {{ stylua }} --respect-ignores --check .
+
+lint-format-rust:
+    {{ cargo }} +nightly fmt --check
+
+lint-license:
+    {{ reuse }} lint
+
+[working-directory("nvim-plugin")]
+lint-lua:
+    {{ luacheck }} .
+
+lint-manifests:
+    {{ cargo-deny }} check
+
+lint-rust:
+    {{ cargo }} clippy
+
+test: test-cargo
+
+test-cargo:
+    {{ cargo }} test
+
+fuzz:
+    {{ cargo }} test --test fuzzer
+
+# Verify all the things: check, lint, test, and fuzz.
+[parallel]
+perfect: check lint test fuzz

--- a/Justfile
+++ b/Justfile
@@ -21,12 +21,15 @@ set shell := ['bash', '-eu', '-c']
 set positional-arguments
 set unstable
 
+[group('check')]
 [parallel]
 check: check-cargo check-typos
 
+[group('check')]
 check-cargo:
     {{ cargo }} check
 
+[group('check')]
 check-typos:
     {{ typos }}
 
@@ -35,52 +38,68 @@ check-typos:
 @list:
     {{ just }} --list --unsorted
 
+[group('build')]
 build *ARGS:
     {{ cargo }} build {{ ARGS }}
 
+[group('build')]
 build-release: (build "--release")
 
+[group('format')]
 [parallel]
 format: format-lua format-rust
 
+[group('format')]
 [working-directory("nvim-plugin")]
 format-lua:
     {{ stylua }} --respect-ignores .
 
+[group('format')]
 format-rust:
     {{ cargo }} +nightly fmt
 
+[group('lint')]
 [parallel]
 lint: lint-format lint-license lint-lua lint-manifests lint-rust
 
+[group('lint')]
 [parallel]
 lint-format: lint-format-lua lint-format-rust
 
+[group('lint')]
 [working-directory("nvim-plugin")]
 lint-format-lua:
     {{ stylua }} --respect-ignores --check .
 
+[group('lint')]
 lint-format-rust:
     {{ cargo }} +nightly fmt --check
 
+[group('lint')]
 lint-license:
     {{ reuse }} lint
 
+[group('lint')]
 [working-directory("nvim-plugin")]
 lint-lua:
     {{ luacheck }} .
 
+[group('lint')]
 lint-manifests:
     {{ cargo-deny }} check
 
+[group('lint')]
 lint-rust:
     {{ cargo }} clippy
 
+[group('test')]
 test: test-cargo
 
+[group('test')]
 test-cargo:
     {{ cargo }} test
 
+[group('test')]
 fuzz:
     {{ cargo }} test --test fuzzer
 

--- a/Justfile
+++ b/Justfile
@@ -23,11 +23,11 @@ set unstable
 
 [group('check')]
 [parallel]
-check: check-cargo check-typos
+check *ARGS: (check-cargo ARGS) check-typos
 
 [group('check')]
-check-cargo:
-    {{ cargo }} check
+check-cargo *ARGS:
+    {{ cargo }} check {{ ARGS }}
 
 [group('check')]
 check-typos:
@@ -93,11 +93,11 @@ lint-rust:
     {{ cargo }} clippy
 
 [group('test')]
-test: test-cargo
+test *ARGS: (test-cargo ARGS)
 
 [group('test')]
-test-cargo:
-    {{ cargo }} test
+test-cargo *ARGS:
+    {{ cargo }} test {{ ARGS }}
 
 [group('test')]
 fuzz:

--- a/crates/e2e-tests/tests/nvim-plugin.rs
+++ b/crates/e2e-tests/tests/nvim-plugin.rs
@@ -100,6 +100,7 @@ async fn nvim_processes_deltas_correctly() {
     )
     .await;
 
+    // typos:ignore-next-line
     assert_nvim_deltas_yield_content("ba\nna\nnas", vec![replace_ed((0, 1), (2, 1), "")], "bas")
         .await;
 

--- a/crates/teamtype/src/types.rs
+++ b/crates/teamtype/src/types.rs
@@ -898,6 +898,7 @@ mod tests {
 
             // word => vorort
             delta.delete(1);
+            // typos:ignore-next-line
             delta.insert("vor");
             delta.retain(2);
             delta.delete(1);


### PR DESCRIPTION
Stacked on #543.

Still in the creative experimentation phase.

Changelog and release workflow bits not yet in play.

For the Justfile, start with just `just` (or `just list`) to see a list of possible jobs. For my own personal projects I tend to lump a lot of stuff together (one lint task that does all the linting, one format task that does all the formatting, etc.) but when other people are involved I finde they often want to be able to run things on a more granular level or in different increments than I do, so this is on the more granular side. For example you can run `just lint` to do all the linting, but it is split into `just lint-rust` and `just lint-lua` and `just lint-license` and more under the hood, so you can see those jobs avoilable too.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
