### PR TITLE
Exit main loop when daemon error is propogated

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
             let share_config = parse_share_config(cli.command, directory.clone());
             run_daemon(share_config, init).await
         }
-    };
+    }?;
 
     trap_shutdown().await;
 


### PR DESCRIPTION
This is subtle but egregious. In working with signal handling we neglected to check that other abort conditions are handled correctly. The `bail!` macro and other error propogation techniques are used in quite a few places that bubble errors that SHOULD go all the way to the main loop. Well they are going to the main loop, but the way Tokio is handling them it is delaying the resolution of the daemon's Result<> until it absolutely has to.

By preserving the unwrapped() daemon handle instead of the wrapped version we force any possible errors to be propogated into the main loop sooner rather than later.

No changelog necessary since this just makes the things we already fixed since the last release work like they should.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
