### PR TITLE
Update security advisories for workspace

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,7 @@ ignore = [
     "RUSTSEC-2024-0436", # unmaintained: paste (via iroh)
     "RUSTSEC-2025-0052", # unmaintained: async-std (via magic-wormhole)
     "RUSTSEC-2026-0049", # vulnerable: rustls-webpki (via iroh)
-    "RUSTSEC-2026-0097", # unsound: rand (via iroh)
+    "RUSTSEC-2026-0058", # unmaintained: tokio-io (via futures)
     "RUSTSEC-2026-0098", # vulnerable: rustls-webpki (via iroh)
     "RUSTSEC-2026-0099", # vulnerable: rustls-webpki (via iroh)
     "RUSTSEC-2026-0104", # reachable panic: rustls-webpki (via iroh)
@@ -35,6 +35,7 @@ allow = [
     "CDLA-Permissive-2.0",
     "GPL-3.0-only",
     "ISC",
+    "LGPL-3.0",
     "MIT",
     "MPL-2.0",
     "Unicode-3.0",


### PR DESCRIPTION
When I re-arranged everything into one proper workspace, I neglected to recheck the current advisories. It turns out the shuffle brought a couple changes. Because the e2e tests with Neovim and fuzzing came into scope, running the same advisory checks against them brings a new license (a new-old licensse with a deprecated SPDX format, but that isn't our fault) and a new advisory. Additionally one other advisory is no longer being hit, and this seems to be related to how the Cargo resolver worked out which patch version of `rand` to use. With the e2e tests being in the same workspace even though we don't have them using the same version it has resolved the usages to both an older and a newer version and resolved one advisory for us.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
