### PR TITLE
Adjust Lua formatting rules and restyle

### DIFF
--- a/.github/workflows/nvim-plugin.yml
+++ b/.github/workflows/nvim-plugin.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: JohnnyMorganz/stylua-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.20.0
+          version: 2.5.2
           args: --config-path nvim-plugin/.stylua.toml --check nvim-plugin
       - name: Luacheck Linting
         uses: lunarmodules/luacheck@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     -   id: cargo-check
         args: []
 -   repo: https://github.com/JohnnyMorganz/StyLua
-    rev: v2.1.0
+    rev: v2.5.2
     hooks:
     -   id: stylua
         args: ['--config-path', 'nvim-plugin/.stylua.toml', '--check', 'nvim-plugin']

--- a/nvim-plugin/.stylua.toml
+++ b/nvim-plugin/.stylua.toml
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
 indent_type = "Spaces"
+indent_width = 3
 quote_style = "ForceDouble"
 space_after_function_names = "Definitions"

--- a/nvim-plugin/.stylua.toml
+++ b/nvim-plugin/.stylua.toml
@@ -4,3 +4,4 @@
 
 indent_type = "Spaces"
 quote_style = "ForceDouble"
+space_after_function_names = "Definitions"

--- a/nvim-plugin/lua/teamtype.lua
+++ b/nvim-plugin/lua/teamtype.lua
@@ -22,333 +22,333 @@ local configurations = {}
 -- buffers: list of attached buffers
 local clients = {}
 
-function M.config(name, cfg)
-    if cfg.cmd == nil then
-        error("Configuration '" .. name .. "' should have a `cmd` to specify which collaboration tool to launch.")
-    end
+function M.config (name, cfg)
+   if cfg.cmd == nil then
+      error("Configuration '" .. name .. "' should have a `cmd` to specify which collaboration tool to launch.")
+   end
 
-    if cfg.root_markers == nil and cfg.root_dir == nil then
-        error(
-            "Configuration '"
-                .. name
-                .. "' should either have a `root_markers` or a `root_dir` to determine launch condition."
-        )
-    end
-    configurations[name] = { cfg = cfg, enabled = false }
+   if cfg.root_markers == nil and cfg.root_dir == nil then
+      error(
+         "Configuration '"
+            .. name
+            .. "' should either have a `root_markers` or a `root_dir` to determine launch condition."
+      )
+   end
+   configurations[name] = { cfg = cfg, enabled = false }
 end
 
-function M.enable(name, enable)
-    if enable == nil then
-        enable = true
-    end
+function M.enable (name, enable)
+   if enable == nil then
+      enable = true
+   end
 
-    configurations[name].enabled = enable
+   configurations[name].enabled = enable
 end
 
-function M.status()
-    if #clients == 0 then
-        return ""
-    end
+function M.status ()
+   if #clients == 0 then
+      return ""
+   end
 
-    local result = "Teamtype: "
+   local result = "Teamtype: "
 
-    local n = cursor.number_of_cursors()
-    if n > 0 then
-        result = result .. cursor.short_cursor_description()
-    else
-        result = result .. "active"
-    end
+   local n = cursor.number_of_cursors()
+   if n > 0 then
+      result = result .. cursor.short_cursor_description()
+   else
+      result = result .. "active"
+   end
 
-    return result
+   return result
 end
 
 -- Take an operation from the daemon and apply it to the editor.
-local function process_operation_for_editor(client, method, parameters)
-    if method == "edit" then
-        local uri = parameters.uri
-        -- TODO: Determine the proper filepath (relative to project dir).
-        local filepath = vim.uri_to_fname(uri)
-        local delta = parameters.delta
-        local the_editor_revision = parameters.revision
+local function process_operation_for_editor (client, method, parameters)
+   if method == "edit" then
+      local uri = parameters.uri
+      -- TODO: Determine the proper filepath (relative to project dir).
+      local filepath = vim.uri_to_fname(uri)
+      local delta = parameters.delta
+      local the_editor_revision = parameters.revision
 
-        -- Check if operation is up-to-date to our content.
-        -- If it's not, ignore it! The daemon will send a transformed one later.
-        if the_editor_revision == client.files[filepath].editor_revision then
-            -- Find correct buffer to apply edits to.
-            local bufnr = vim.uri_to_bufnr(uri)
+      -- Check if operation is up-to-date to our content.
+      -- If it's not, ignore it! The daemon will send a transformed one later.
+      if the_editor_revision == client.files[filepath].editor_revision then
+         -- Find correct buffer to apply edits to.
+         local bufnr = vim.uri_to_bufnr(uri)
 
-            changetracker.apply_delta(bufnr, delta)
+         changetracker.apply_delta(bufnr, delta)
 
-            client.files[filepath].daemon_revision = client.files[filepath].daemon_revision + 1
-        end
-    elseif method == "cursor" then
-        cursor.set_cursor(parameters.uri, parameters.userid, parameters.name, parameters.ranges)
-    else
-        print("Unknown method: " .. method)
-    end
+         client.files[filepath].daemon_revision = client.files[filepath].daemon_revision + 1
+      end
+   elseif method == "cursor" then
+      cursor.set_cursor(parameters.uri, parameters.userid, parameters.name, parameters.ranges)
+   else
+      print("Unknown method: " .. method)
+   end
 end
 
 -- Disabling 'autoread' prevents Neovim from reloading the file when it changes externally,
 -- but only in the case where the buffer hasn't been modified in Neovim already.
 -- For the conflicting case, we prevent a popup dialog by setting the FileChangedShell autocommand below.
-local function ensure_autoread_is_off()
-    if vim.o.autoread then
-        vim.bo.autoread = false
-    end
+local function ensure_autoread_is_off ()
+   if vim.o.autoread then
+      vim.bo.autoread = false
+   end
 end
 
 -- In teamtype-enabled buffers, "writing" is no longer a concept. We also want to avoid error messages
 -- when the file has changed on disk, so make all writing operations a no-op.
-local function disable_writing()
-    local buf = vim.api.nvim_get_current_buf()
-    local autocmd_arg = {
-        buffer = buf,
-        callback = function()
-            -- Trigger this autocommand so that plugins like autoformatters still work.
-            vim.api.nvim_exec_autocmds("BufWritePre", {
-                buffer = buf,
-            })
-        end,
-    }
-    vim.api.nvim_create_autocmd("BufWriteCmd", autocmd_arg)
-    vim.api.nvim_create_autocmd("FileWriteCmd", autocmd_arg)
-    vim.api.nvim_create_autocmd("FileAppendCmd", autocmd_arg)
+local function disable_writing ()
+   local buf = vim.api.nvim_get_current_buf()
+   local autocmd_arg = {
+      buffer = buf,
+      callback = function ()
+         -- Trigger this autocommand so that plugins like autoformatters still work.
+         vim.api.nvim_exec_autocmds("BufWritePre", {
+            buffer = buf,
+         })
+      end,
+   }
+   vim.api.nvim_create_autocmd("BufWriteCmd", autocmd_arg)
+   vim.api.nvim_create_autocmd("FileWriteCmd", autocmd_arg)
+   vim.api.nvim_create_autocmd("FileAppendCmd", autocmd_arg)
 end
 
-local function track_edits(client, filename, uri, initial_lines)
-    client.files[filename] = {
-        -- Number of operations the daemon has made.
-        daemon_revision = 0,
-        -- Number of operations we have made.
-        editor_revision = 0,
-    }
+local function track_edits (client, filename, uri, initial_lines)
+   client.files[filename] = {
+      -- Number of operations the daemon has made.
+      daemon_revision = 0,
+      -- Number of operations we have made.
+      editor_revision = 0,
+   }
 
-    local bufnr = vim.uri_to_bufnr(uri)
+   local bufnr = vim.uri_to_bufnr(uri)
 
-    changetracker.track_changes(bufnr, initial_lines, function(delta)
-        client.files[filename].editor_revision = client.files[filename].editor_revision + 1
+   changetracker.track_changes(bufnr, initial_lines, function (delta)
+      client.files[filename].editor_revision = client.files[filename].editor_revision + 1
 
-        local params = { uri = uri, delta = delta, revision = client.files[filename].daemon_revision }
+      local params = { uri = uri, delta = delta, revision = client.files[filename].daemon_revision }
 
-        client.connection:send_request("edit", params)
-    end)
-    cursor.track_cursor(bufnr, function(ranges)
-        local params = { uri = uri, ranges = ranges }
-        -- Even though it's not "needed" we're sending requests in this case
-        -- to ensure we're processing/seeing potential errors.
-        client.connection:send_request("cursor", params)
-    end)
+      client.connection:send_request("edit", params)
+   end)
+   cursor.track_cursor(bufnr, function (ranges)
+      local params = { uri = uri, ranges = ranges }
+      -- Even though it's not "needed" we're sending requests in this case
+      -- to ensure we're processing/seeing potential errors.
+      client.connection:send_request("cursor", params)
+   end)
 end
 
-local function find_or_create_client(config_name, root_dir)
-    -- We re-use connections for configs with the same name and root_dir.
-    for _, client in ipairs(clients) do
-        if client.name == config_name and client.root_dir == root_dir then
-            return client
-        end
-    end
+local function find_or_create_client (config_name, root_dir)
+   -- We re-use connections for configs with the same name and root_dir.
+   for _, client in ipairs(clients) do
+      if client.name == config_name and client.root_dir == root_dir then
+         return client
+      end
+   end
 
-    -- No reusable connection? Let's create a new one.
-    local client = {
-        name = config_name,
-        root_dir = root_dir,
-        files = {},
-        buffers = {},
-        connection = nil,
-    }
+   -- No reusable connection? Let's create a new one.
+   local client = {
+      name = config_name,
+      root_dir = root_dir,
+      files = {},
+      buffers = {},
+      connection = nil,
+   }
 
-    -- TODO: Encapsulate these dispatchers in the connection module better?
-    local dispatchers = {
-        notification = function(m, p)
-            process_operation_for_editor(client, m, p)
-        end,
-        on_error = function(code, ...)
-            print("Teamtype connection error: ", code, vim.inspect({ ... }))
-        end,
-        on_exit = function(code, _)
-            if code == 0 then
-                vim.schedule(function()
-                    vim.api.nvim_err_writeln(
-                        "Connection to Teamtype daemon lost. Probably it crashed or was stopped. Please restart the daemon, then Neovim."
-                    )
-                end)
-            else
-                print(
-                    "Could not connect to Teamtype daemon. Did you start it (in "
-                        .. root_dir
-                        .. ")? To stop trying, remove the .teamtype/ directory."
-                )
-            end
-
-            vim.schedule(function()
-                -- React to disconnect.
-                local to_remove = {}
-                for i, c in ipairs(clients) do
-                    if c == client then
-                        to_remove[i] = true
-
-                        -- If the daemon crashed, prevent modifications to the buffers to save users from
-                        -- accidental data losss.
-                        if code == 0 then
-                            for _, buf_nr in ipairs(c.buffers) do
-                                vim.bo[buf_nr].modifiable = false
-
-                                -- TODO: Enable writing here again, so that user can make backup of file?
-                            end
-                        end
-                    end
-                end
-
-                -- Remove from clients list.
-                for i = #clients, 1, -1 do
-                    if to_remove[i] then
-                        table.remove(clients, i)
-                    end
-                end
+   -- TODO: Encapsulate these dispatchers in the connection module better?
+   local dispatchers = {
+      notification = function (m, p)
+         process_operation_for_editor(client, m, p)
+      end,
+      on_error = function (code, ...)
+         print("Teamtype connection error: ", code, vim.inspect({ ... }))
+      end,
+      on_exit = function (code, _)
+         if code == 0 then
+            vim.schedule(function ()
+               vim.api.nvim_err_writeln(
+                  "Connection to Teamtype daemon lost. Probably it crashed or was stopped. Please restart the daemon, then Neovim."
+               )
             end)
-        end,
-    }
+         else
+            print(
+               "Could not connect to Teamtype daemon. Did you start it (in "
+                  .. root_dir
+                  .. ")? To stop trying, remove the .teamtype/ directory."
+            )
+         end
 
-    local the_connection = connection.connect(configurations[config_name].cfg.cmd, root_dir, dispatchers)
-    client.connection = the_connection
-    table.insert(clients, client)
+         vim.schedule(function ()
+            -- React to disconnect.
+            local to_remove = {}
+            for i, c in ipairs(clients) do
+               if c == client then
+                  to_remove[i] = true
 
-    return client
-end
+                  -- If the daemon crashed, prevent modifications to the buffers to save users from
+                  -- accidental data losss.
+                  if code == 0 then
+                     for _, buf_nr in ipairs(c.buffers) do
+                        vim.bo[buf_nr].modifiable = false
 
-local function activate_config_for_buffer(config_name, buf_nr, root_dir)
-    local client = find_or_create_client(config_name, root_dir)
-    table.insert(client.buffers, buf_nr)
-
-    local filename = vim.api.nvim_buf_get_name(buf_nr)
-    local uri = vim.uri_from_bufnr(buf_nr)
-
-    -- Neovim enables eol for an empty file, but we do use this option values
-    -- assuming there's a trailing newline iff eol is true.
-    if vim.fn.getfsize(vim.api.nvim_buf_get_name(buf_nr)) == 0 then
-        vim.bo.eol = false
-    end
-
-    local lines = changetracker.get_all_lines_respecting_eol(buf_nr)
-    local content = table.concat(lines, "\n")
-
-    -- Ensure that the file exists on disk before we "open" it in the daemon,
-    -- to prevent a warning that the file has been created externally (W13).
-    -- This resolves issue #92.
-    if string.find(uri, "file://") == 1 and vim.fn.filereadable(filename) == 0 then
-        vim.cmd("silent write")
-    end
-
-    client.connection:send_request("open", { uri = uri, content = content }, function()
-        debug("Tracking Edits")
-        ensure_autoread_is_off()
-        disable_writing()
-        track_edits(client, filename, uri, lines)
-    end)
-end
-
-local function on_buffer_open()
-    local buf_nr = tonumber(vim.fn.expand("<abuf>"))
-    local buf_name = vim.api.nvim_buf_get_name(buf_nr)
-
-    -- Early return to avoid unnamed buffers such as diagnostics
-    -- Resolves #491
-    if buf_name == "" then
-        return
-    end
-
-    for name, server in pairs(configurations) do
-        if server.enabled then
-            if server.cfg.root_dir then
-                server.cfg.root_dir(buf_nr, function(root_dir)
-                    activate_config_for_buffer(name, buf_nr, root_dir)
-                end)
-            elseif server.cfg.root_markers then
-                local uri = vim.uri_from_bufnr(buf_nr)
-                if string.find(uri, "file://") == 1 then
-                    local root_dir = helpers.find_directory(buf_name, server.cfg.root_markers)
-                    if root_dir then
-                        activate_config_for_buffer(name, buf_nr, root_dir)
-                    end
-                else
-                    debug(
-                        "Did not activate '"
-                            .. name
-                            .. "' configuration for non-file buffer despite having a `root_markers` configured."
-                    )
-                end
+                        -- TODO: Enable writing here again, so that user can make backup of file?
+                     end
+                  end
+               end
             end
-        end
-    end
-end
 
-local function on_buffer_close()
-    local buf_nr = tonumber(vim.fn.expand("<abuf>"))
-    local closed_file = vim.fn.expand("<afile>:p")
-
-    if closed_file == "" then
-        -- This is a temporary buffer without a name.
-        return
-    end
-
-    debug("on_buffer_close: " .. closed_file)
-
-    -- Find the correct client, and remove this buffer from it.
-    for _, client in ipairs(clients) do
-        for j, buffer in ipairs(client.buffers) do
-            if buffer == buf_nr then
-                client.files[closed_file] = nil
-
-                local uri = vim.uri_from_bufnr(buf_nr)
-                client.connection:send_notification("close", { uri = uri })
-                table.remove(client.buffers, j)
+            -- Remove from clients list.
+            for i = #clients, 1, -1 do
+               if to_remove[i] then
+                  table.remove(clients, i)
+               end
             end
-        end
-    end
+         end)
+      end,
+   }
+
+   local the_connection = connection.connect(configurations[config_name].cfg.cmd, root_dir, dispatchers)
+   client.connection = the_connection
+   table.insert(clients, client)
+
+   return client
 end
 
-local function print_info()
-    if #clients == 0 then
-        print("Not connected to any Teamtype daemon.")
-        return
-    end
+local function activate_config_for_buffer (config_name, buf_nr, root_dir)
+   local client = find_or_create_client(config_name, root_dir)
+   table.insert(client.buffers, buf_nr)
 
-    local result = "Clients:\n\n"
+   local filename = vim.api.nvim_buf_get_name(buf_nr)
+   local uri = vim.uri_from_bufnr(buf_nr)
 
-    for _, client in ipairs(clients) do
-        result = result .. "\"" .. client.name .. "\" in '" .. client.root_dir .. "'\n"
-    end
+   -- Neovim enables eol for an empty file, but we do use this option values
+   -- assuming there's a trailing newline iff eol is true.
+   if vim.fn.getfsize(vim.api.nvim_buf_get_name(buf_nr)) == 0 then
+      vim.bo.eol = false
+   end
 
-    result = result .. "\nCursors:\n\n" .. cursor.list_cursors()
+   local lines = changetracker.get_all_lines_respecting_eol(buf_nr)
+   local content = table.concat(lines, "\n")
 
-    print(result)
+   -- Ensure that the file exists on disk before we "open" it in the daemon,
+   -- to prevent a warning that the file has been created externally (W13).
+   -- This resolves issue #92.
+   if string.find(uri, "file://") == 1 and vim.fn.filereadable(filename) == 0 then
+      vim.cmd("silent write")
+   end
+
+   client.connection:send_request("open", { uri = uri, content = content }, function ()
+      debug("Tracking Edits")
+      ensure_autoread_is_off()
+      disable_writing()
+      track_edits(client, filename, uri, lines)
+   end)
 end
 
-local function legacy_command(f)
-    return function()
-        print("You are using a deprecated user command Ethersync*. Please use the corresponding Teamtype* instead.")
-        f()
-    end
+local function on_buffer_open ()
+   local buf_nr = tonumber(vim.fn.expand("<abuf>"))
+   local buf_name = vim.api.nvim_buf_get_name(buf_nr)
+
+   -- Early return to avoid unnamed buffers such as diagnostics
+   -- Resolves #491
+   if buf_name == "" then
+      return
+   end
+
+   for name, server in pairs(configurations) do
+      if server.enabled then
+         if server.cfg.root_dir then
+            server.cfg.root_dir(buf_nr, function (root_dir)
+               activate_config_for_buffer(name, buf_nr, root_dir)
+            end)
+         elseif server.cfg.root_markers then
+            local uri = vim.uri_from_bufnr(buf_nr)
+            if string.find(uri, "file://") == 1 then
+               local root_dir = helpers.find_directory(buf_name, server.cfg.root_markers)
+               if root_dir then
+                  activate_config_for_buffer(name, buf_nr, root_dir)
+               end
+            else
+               debug(
+                  "Did not activate '"
+                     .. name
+                     .. "' configuration for non-file buffer despite having a `root_markers` configured."
+               )
+            end
+         end
+      end
+   end
 end
 
-local function activate_plugin()
-    vim.api.nvim_create_autocmd({ "BufRead" }, { callback = on_buffer_open })
-    vim.api.nvim_create_autocmd({ "BufNewFile" }, { callback = on_buffer_open })
-    vim.api.nvim_create_autocmd("BufUnload", { callback = on_buffer_close })
+local function on_buffer_close ()
+   local buf_nr = tonumber(vim.fn.expand("<abuf>"))
+   local closed_file = vim.fn.expand("<afile>:p")
 
-    -- This autocommand prevents that, when a file changes on disk while Neovim has the file open,
-    -- it should not attempt to reload it. Related to issue #176.
-    vim.api.nvim_create_autocmd("FileChangedShell", { callback = function() end })
+   if closed_file == "" then
+      -- This is a temporary buffer without a name.
+      return
+   end
 
-    vim.api.nvim_create_user_command("TeamtypeInfo", print_info, {})
-    vim.api.nvim_create_user_command("TeamtypeJumpToCursor", cursor.jump_to_cursor, {})
-    vim.api.nvim_create_user_command("TeamtypeFollow", cursor.follow_cursor, {})
+   debug("on_buffer_close: " .. closed_file)
 
-    -- Support the old commands for a while, as they might be residing in user configurations.
-    -- TODO: Remove this after a while.
-    vim.api.nvim_create_user_command("EthersyncInfo", legacy_command(print_info), {})
-    vim.api.nvim_create_user_command("EthersyncJumpToCursor", legacy_command(cursor.jump_to_cursor), {})
-    vim.api.nvim_create_user_command("EthersyncFollow", legacy_command(cursor.follow_cursor), {})
+   -- Find the correct client, and remove this buffer from it.
+   for _, client in ipairs(clients) do
+      for j, buffer in ipairs(client.buffers) do
+         if buffer == buf_nr then
+            client.files[closed_file] = nil
+
+            local uri = vim.uri_from_bufnr(buf_nr)
+            client.connection:send_notification("close", { uri = uri })
+            table.remove(client.buffers, j)
+         end
+      end
+   end
+end
+
+local function print_info ()
+   if #clients == 0 then
+      print("Not connected to any Teamtype daemon.")
+      return
+   end
+
+   local result = "Clients:\n\n"
+
+   for _, client in ipairs(clients) do
+      result = result .. "\"" .. client.name .. "\" in '" .. client.root_dir .. "'\n"
+   end
+
+   result = result .. "\nCursors:\n\n" .. cursor.list_cursors()
+
+   print(result)
+end
+
+local function legacy_command (f)
+   return function ()
+      print("You are using a deprecated user command Ethersync*. Please use the corresponding Teamtype* instead.")
+      f()
+   end
+end
+
+local function activate_plugin ()
+   vim.api.nvim_create_autocmd({ "BufRead" }, { callback = on_buffer_open })
+   vim.api.nvim_create_autocmd({ "BufNewFile" }, { callback = on_buffer_open })
+   vim.api.nvim_create_autocmd("BufUnload", { callback = on_buffer_close })
+
+   -- This autocommand prevents that, when a file changes on disk while Neovim has the file open,
+   -- it should not attempt to reload it. Related to issue #176.
+   vim.api.nvim_create_autocmd("FileChangedShell", { callback = function () end })
+
+   vim.api.nvim_create_user_command("TeamtypeInfo", print_info, {})
+   vim.api.nvim_create_user_command("TeamtypeJumpToCursor", cursor.jump_to_cursor, {})
+   vim.api.nvim_create_user_command("TeamtypeFollow", cursor.follow_cursor, {})
+
+   -- Support the old commands for a while, as they might be residing in user configurations.
+   -- TODO: Remove this after a while.
+   vim.api.nvim_create_user_command("EthersyncInfo", legacy_command(print_info), {})
+   vim.api.nvim_create_user_command("EthersyncJumpToCursor", legacy_command(cursor.jump_to_cursor), {})
+   vim.api.nvim_create_user_command("EthersyncFollow", legacy_command(cursor.follow_cursor), {})
 end
 
 activate_plugin()

--- a/nvim-plugin/lua/teamtype/changetracker.lua
+++ b/nvim-plugin/lua/teamtype/changetracker.lua
@@ -13,259 +13,254 @@ local M = {}
 local ignore_edits = false
 
 -- Get the "logical" buffer content, including the optional last newline.
-function M.get_all_lines_respecting_eol(buffer)
-    local lines = vim.api.nvim_buf_get_lines(buffer, 0, -1, true)
+function M.get_all_lines_respecting_eol (buffer)
+   local lines = vim.api.nvim_buf_get_lines(buffer, 0, -1, true)
 
-    -- If eol is on, that's like a virtual empty line after the current lines.
-    if vim.bo[buffer].eol then
-        table.insert(lines, "")
-    end
+   -- If eol is on, that's like a virtual empty line after the current lines.
+   if vim.bo[buffer].eol then
+      table.insert(lines, "")
+   end
 
-    return lines
+   return lines
 end
 
 -- Checks whether an TextDocumentContentChangeEvent has no effect.
-local function is_empty(diff)
-    return diff.text == ""
-        and diff.range["start"].line == diff.range["end"].line
-        and diff.range["start"].character == diff.range["end"].character
+local function is_empty (diff)
+   return diff.text == ""
+      and diff.range["start"].line == diff.range["end"].line
+      and diff.range["start"].character == diff.range["end"].character
 end
 
 -- Convert an LSP TextDocumentContentChangeEvent to a Teamtype delta.
-local function lsp_diff_to_teamtype_delta(diff)
-    return {
-        {
-            range = diff.range,
-            replacement = diff.text,
-        },
-    }
+local function lsp_diff_to_teamtype_delta (diff)
+   return {
+      {
+         range = diff.range,
+         replacement = diff.text,
+      },
+   }
 end
 
 -- Convert a Teamtype delta to a list of LSP `TextEdit`s.
-local function teamtype_delta_to_lsp_text_edits(delta)
-    local text_edits = {}
-    for _, replacement in ipairs(delta) do
-        local text_edit = {
-            range = replacement.range,
-            newText = replacement.replacement,
-        }
-        table.insert(text_edits, text_edit)
-    end
-    return text_edits
+local function teamtype_delta_to_lsp_text_edits (delta)
+   local text_edits = {}
+   for _, replacement in ipairs(delta) do
+      local text_edit = {
+         range = replacement.range,
+         newText = replacement.replacement,
+      }
+      table.insert(text_edits, text_edit)
+   end
+   return text_edits
 end
 
 -- Shrink first_line, last_line and new_last_line to only contain the lines that are actually different.
-local function shrink_to_modified_line_range(prev_lines, curr_lines, first_line, last_line, new_last_line)
-    while
-        first_line < last_line
-        and first_line < new_last_line
-        and prev_lines[first_line + 1] == curr_lines[first_line + 1]
-    do
-        first_line = first_line + 1
-    end
+local function shrink_to_modified_line_range (prev_lines, curr_lines, first_line, last_line, new_last_line)
+   while
+      first_line < last_line
+      and first_line < new_last_line
+      and prev_lines[first_line + 1] == curr_lines[first_line + 1]
+   do
+      first_line = first_line + 1
+   end
 
-    while
-        last_line == new_last_line
-        and last_line > first_line + 1
-        and prev_lines[last_line] == curr_lines[last_line]
-    do
-        last_line = last_line - 1
-        new_last_line = new_last_line - 1
-    end
-    return first_line, last_line, new_last_line
+   while last_line == new_last_line and last_line > first_line + 1 and prev_lines[last_line] == curr_lines[last_line] do
+      last_line = last_line - 1
+      new_last_line = new_last_line - 1
+   end
+   return first_line, last_line, new_last_line
 end
 
 -- Fix some aspects of the TextDocumentContentChangeEvent produced by vim.lsp.sync.compute_diff
 -- to make them more concise, or more logical. Often, this has something to do with the final newline.
-local function fix_diff(diff, prev_lines, curr_lines)
-    -- Note: line/character indices in diff are zero-based.
+local function fix_diff (diff, prev_lines, curr_lines)
+   -- Note: line/character indices in diff are zero-based.
 
-    -- Special case: If the entire content is deleted, undo the special treatment introduced in
-    -- https://github.com/neovim/neovim/pull/29904. We think it's incorrect. :P
-    if #curr_lines == 1 and curr_lines[1] == "" then
-        diff.range["start"].line = 0
-    end
+   -- Special case: If the entire content is deleted, undo the special treatment introduced in
+   -- https://github.com/neovim/neovim/pull/29904. We think it's incorrect. :P
+   if #curr_lines == 1 and curr_lines[1] == "" then
+      diff.range["start"].line = 0
+   end
 
-    -- TODO: Simplify the solution?
-    -- For example, pull tests into good variable names like "ends_with_newline".
-    -- TODO: Update the following comment to describe the problem and the solution more clearly.
+   -- TODO: Simplify the solution?
+   -- For example, pull tests into good variable names like "ends_with_newline".
+   -- TODO: Update the following comment to describe the problem and the solution more clearly.
 
-    -- Sometimes, Neovim deletes full lines by deleting the last line, plus an imaginary newline at the end. For example, to delete the second line, Neovim would delete from (line: 1, column: 0) to (line: 2, column 0).
-    -- But, in the case of deleting the last line, what we expect in the rest of Teamtype is to delete the newline *before* the line.
-    -- So let's change the deleted range to (line: 0, column: [last character of the first line]) to (line: 1, column: [last character of the second line]).
+   -- Sometimes, Neovim deletes full lines by deleting the last line, plus an imaginary newline at the end. For example, to delete the second line, Neovim would delete from (line: 1, column: 0) to (line: 2, column 0).
+   -- But, in the case of deleting the last line, what we expect in the rest of Teamtype is to delete the newline *before* the line.
+   -- So let's change the deleted range to (line: 0, column: [last character of the first line]) to (line: 1, column: [last character of the second line]).
 
-    if diff.range["end"].line == #prev_lines then
-        -- Range spans to a line one after the visible buffer lines.
-        if diff.range["start"].line == 0 then
-            -- The range starts on the first line, so we can't "shift the range backwards".
-            -- Instead, we just shorten the range by one character.
-            diff.range["end"].line = diff.range["end"].line - 1
-            diff.range["end"].character = vim.fn.strchars(prev_lines[#prev_lines])
+   if diff.range["end"].line == #prev_lines then
+      -- Range spans to a line one after the visible buffer lines.
+      if diff.range["start"].line == 0 then
+         -- The range starts on the first line, so we can't "shift the range backwards".
+         -- Instead, we just shorten the range by one character.
+         diff.range["end"].line = diff.range["end"].line - 1
+         diff.range["end"].character = vim.fn.strchars(prev_lines[#prev_lines])
+         if string.sub(diff.text, -1) == "\n" then
+            -- The replacement ends with a newline.
+            -- Drop it, because we shortened the range not to include the newline.
+            diff.text = string.sub(diff.text, 1, -2)
+         end
+      else
+         -- The range doesn't start on the first line.
+         if diff.range["end"].character == 0 then
+            -- The range ends at the beginning of the line after the visible lines.
             if string.sub(diff.text, -1) == "\n" then
-                -- The replacement ends with a newline.
-                -- Drop it, because we shortened the range not to include the newline.
-                diff.text = string.sub(diff.text, 1, -2)
-            end
-        else
-            -- The range doesn't start on the first line.
-            if diff.range["end"].character == 0 then
-                -- The range ends at the beginning of the line after the visible lines.
-                if string.sub(diff.text, -1) == "\n" then
-                    -- The replacement ends with a newline.
-                    -- Drop it, and shorten the range by one character.
-                    diff.text = string.sub(diff.text, 1, -2)
-                    diff.range["end"].line = diff.range["end"].line - 1
-                    diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1])
-                elseif diff.range["start"].character == 0 then
-                    -- Operation applies to beginning of lines, that means it's possible to shift it back.
-                    -- Modify edit, s.t. not the last \n, but the one before is replaced.
-                    diff.range["start"].line = diff.range["start"].line - 1
-                    diff.range["end"].line = diff.range["end"].line - 1
-                    diff.range["start"].character = vim.fn.strchars(prev_lines[diff.range["start"].line + 1])
-                    diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1])
-                else
-                    vim.api.nvim_err_writeln(
-                        "[teamtype] We don't know how to handle this case for a deletion after the last visible line. Please file a bug."
-                    )
-                end
+               -- The replacement ends with a newline.
+               -- Drop it, and shorten the range by one character.
+               diff.text = string.sub(diff.text, 1, -2)
+               diff.range["end"].line = diff.range["end"].line - 1
+               diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1])
+            elseif diff.range["start"].character == 0 then
+               -- Operation applies to beginning of lines, that means it's possible to shift it back.
+               -- Modify edit, s.t. not the last \n, but the one before is replaced.
+               diff.range["start"].line = diff.range["start"].line - 1
+               diff.range["end"].line = diff.range["end"].line - 1
+               diff.range["start"].character = vim.fn.strchars(prev_lines[diff.range["start"].line + 1])
+               diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1])
             else
-                vim.api.nvim_err_writeln(
-                    "[teamtype] We think a delta ending inside the line after the visible ones cannot happen. Please file a bug."
-                )
+               vim.api.nvim_err_writeln(
+                  "[teamtype] We don't know how to handle this case for a deletion after the last visible line. Please file a bug."
+               )
             end
-        end
-    end
+         else
+            vim.api.nvim_err_writeln(
+               "[teamtype] We think a delta ending inside the line after the visible ones cannot happen. Please file a bug."
+            )
+         end
+      end
+   end
 
-    -- In some cases, we can still want to make the delta prettier.
-    if
-        diff.range["end"].character == 0
-        and string.sub(diff.text, 1, 1) == "\n"
-        and diff.range["start"].character == vim.fn.strchars(prev_lines[diff.range["start"].line + 1])
-        and diff.range["start"].line < diff.range["end"].line
-    then
-        -- Range starts at the end of a line, and spans the newline after it, but also begins with a newline.
-        -- This newline is redundant, and leads to less-pretty diffs. Remove it.
-        diff.text = string.sub(diff.text, 2, -1)
-        diff.range["start"].line = diff.range["start"].line + 1
-        diff.range["start"].character = 0
-    end
+   -- In some cases, we can still want to make the delta prettier.
+   if
+      diff.range["end"].character == 0
+      and string.sub(diff.text, 1, 1) == "\n"
+      and diff.range["start"].character == vim.fn.strchars(prev_lines[diff.range["start"].line + 1])
+      and diff.range["start"].line < diff.range["end"].line
+   then
+      -- Range starts at the end of a line, and spans the newline after it, but also begins with a newline.
+      -- This newline is redundant, and leads to less-pretty diffs. Remove it.
+      diff.text = string.sub(diff.text, 2, -1)
+      diff.range["start"].line = diff.range["start"].line + 1
+      diff.range["start"].character = 0
+   end
 
-    if
-        diff.range["end"].character == 0
-        and string.sub(diff.text, -1) == "\n"
-        and diff.range["start"].line < diff.range["end"].line
-    then
-        -- Range ends on the beginning of a line, but the replacement ends with a newline.
-        -- This newline is redundant, and leads to less-pretty diffs. Remove it.
-        diff.text = string.sub(diff.text, 1, -2)
-        diff.range["end"].line = diff.range["end"].line - 1
-        diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1])
-    end
+   if
+      diff.range["end"].character == 0
+      and string.sub(diff.text, -1) == "\n"
+      and diff.range["start"].line < diff.range["end"].line
+   then
+      -- Range ends on the beginning of a line, but the replacement ends with a newline.
+      -- This newline is redundant, and leads to less-pretty diffs. Remove it.
+      diff.text = string.sub(diff.text, 1, -2)
+      diff.range["end"].line = diff.range["end"].line - 1
+      diff.range["end"].character = vim.fn.strchars(prev_lines[diff.range["end"].line + 1])
+   end
 
-    return diff
+   return diff
 end
 
 -- Subscribes the callback to changes for a given buffer id and reports with a delta.
 --
 -- The delta can be expected to be in the format as specified in the daemon-editor protocol.
-function M.track_changes(buffer, initial_lines, callback)
-    -- Used to remember the previous content of the buffer, so that we can
-    -- calculate the difference between the previous and the current content.
-    local prev_lines = initial_lines
+function M.track_changes (buffer, initial_lines, callback)
+   -- Used to remember the previous content of the buffer, so that we can
+   -- calculate the difference between the previous and the current content.
+   local prev_lines = initial_lines
 
-    -- Computes a Teamtype delta containing the changes between curr_lines and prev_lines.
-    -- If the delta is not empty, call the callback.
-    local function line_change(first_line, last_line, new_last_line)
-        -- TODO: optimize with a cache
-        local curr_lines = M.get_all_lines_respecting_eol(buffer)
+   -- Computes a Teamtype delta containing the changes between curr_lines and prev_lines.
+   -- If the delta is not empty, call the callback.
+   local function line_change (first_line, last_line, new_last_line)
+      -- TODO: optimize with a cache
+      local curr_lines = M.get_all_lines_respecting_eol(buffer)
 
-        local prev_lines_copy = prev_lines
-        prev_lines = curr_lines
+      local prev_lines_copy = prev_lines
+      prev_lines = curr_lines
 
-        -- Are we currently ignoring edits? If so, do nothing.
-        if ignore_edits then
-            return
-        end
+      -- Are we currently ignoring edits? If so, do nothing.
+      if ignore_edits then
+         return
+      end
 
-        -- This is a special case for handling a situation where deleting down to a single empty buffer line, but
-        -- 'eol' is on. In this case, the actual buffer content will be "\n", but that's not always communicated
-        -- correctly.
-        --
-        -- Case 1: Opening "\n\n" and pressing ggdd
-        --    prev = 3*""
-        --    cur = 2*""
-        --    fl = 0, ll = 1, nll = 0
-        -- Case 2: Opening "\n\n" and pressing ggdG
-        --    prev = 3*""
-        --    cur = 2*""
-        --    fl = 0, ll = 2, nll = 0
-        --    => needs to be fixed to ll = 1 OR nll = 1
-        -- Case 3: Opening "a\n" and pressing dd
-        --    prev = "a", ""
-        --    cur = 2*""
-        --    fl = 0, ll = 1, nll = 0
-        --    => needs to be fixed to nll = 1
-        --
-        -- Resulting content of all three cases should be the same: \n
-        if
-            vim.bo[buffer].eol
-            and #curr_lines == 2
-            and curr_lines[1] == ""
-            and new_last_line == 0
-            and (last_line >= 2 or #prev_lines_copy == 2)
-        then
-            new_last_line = 1
-        end
+      -- This is a special case for handling a situation where deleting down to a single empty buffer line, but
+      -- 'eol' is on. In this case, the actual buffer content will be "\n", but that's not always communicated
+      -- correctly.
+      --
+      -- Case 1: Opening "\n\n" and pressing ggdd
+      --    prev = 3*""
+      --    cur = 2*""
+      --    fl = 0, ll = 1, nll = 0
+      -- Case 2: Opening "\n\n" and pressing ggdG
+      --    prev = 3*""
+      --    cur = 2*""
+      --    fl = 0, ll = 2, nll = 0
+      --    => needs to be fixed to ll = 1 OR nll = 1
+      -- Case 3: Opening "a\n" and pressing dd
+      --    prev = "a", ""
+      --    cur = 2*""
+      --    fl = 0, ll = 1, nll = 0
+      --    => needs to be fixed to nll = 1
+      --
+      -- Resulting content of all three cases should be the same: \n
+      if
+         vim.bo[buffer].eol
+         and #curr_lines == 2
+         and curr_lines[1] == ""
+         and new_last_line == 0
+         and (last_line >= 2 or #prev_lines_copy == 2)
+      then
+         new_last_line = 1
+      end
 
-        -- When the line ranges are larger then the actual differences, compute_diff will compute
-        -- unnecessarily large diffs. We can fix this by hand.
-        first_line, last_line, new_last_line =
-            shrink_to_modified_line_range(prev_lines_copy, curr_lines, first_line, last_line, new_last_line)
+      -- When the line ranges are larger then the actual differences, compute_diff will compute
+      -- unnecessarily large diffs. We can fix this by hand.
+      first_line, last_line, new_last_line =
+         shrink_to_modified_line_range(prev_lines_copy, curr_lines, first_line, last_line, new_last_line)
 
-        local diff =
-            sync.compute_diff(prev_lines_copy, curr_lines, first_line, last_line, new_last_line, "utf-32", "\n")
-        diff = fix_diff(diff, prev_lines_copy, curr_lines)
+      local diff = sync.compute_diff(prev_lines_copy, curr_lines, first_line, last_line, new_last_line, "utf-32", "\n")
+      diff = fix_diff(diff, prev_lines_copy, curr_lines)
 
-        if is_empty(diff) then
-            return
-        end
+      if is_empty(diff) then
+         return
+      end
 
-        local delta = lsp_diff_to_teamtype_delta(diff)
-        callback(delta)
-    end
+      local delta = lsp_diff_to_teamtype_delta(diff)
+      callback(delta)
+   end
 
-    -- Step 1: Register a callback to catch all future buffer changes.
-    vim.api.nvim_buf_attach(buffer, false, {
-        on_lines = function(
-            _the_literal_string_lines --[[@diagnostic disable-line]],
-            _buffer_handle --[[@diagnostic disable-line]],
-            _changedtick, --[[@diagnostic disable-line]]
-            first_line,
-            last_line,
-            new_last_line
-        )
-            -- First, clear the "modified" option, so that the buffer is not displayed as dirty.
-            -- Being modified doesn't have meaning for teamtype-enabled files.
-            vim.api.nvim_buf_set_option(buffer, "modified", false)
+   -- Step 1: Register a callback to catch all future buffer changes.
+   vim.api.nvim_buf_attach(buffer, false, {
+      on_lines = function (
+         _the_literal_string_lines --[[@diagnostic disable-line]],
+         _buffer_handle --[[@diagnostic disable-line]],
+         _changedtick, --[[@diagnostic disable-line]]
+         first_line,
+         last_line,
+         new_last_line
+      )
+         -- First, clear the "modified" option, so that the buffer is not displayed as dirty.
+         -- Being modified doesn't have meaning for teamtype-enabled files.
+         vim.api.nvim_buf_set_option(buffer, "modified", false)
 
-            -- Line counts that we get called with are zero-based.
-            -- last_line and new_last_line are exclusive
+         -- Line counts that we get called with are zero-based.
+         -- last_line and new_last_line are exclusive
 
-            line_change(first_line, last_line, new_last_line)
-        end,
-    })
+         line_change(first_line, last_line, new_last_line)
+      end,
+   })
 
-    -- Step 2: Initially compare the current buffer contents to the `initial_lines`, and maybe send out a diff.
-    local curr_lines = M.get_all_lines_respecting_eol(buffer)
-    line_change(0, #prev_lines, #curr_lines)
+   -- Step 2: Initially compare the current buffer contents to the `initial_lines`, and maybe send out a diff.
+   local curr_lines = M.get_all_lines_respecting_eol(buffer)
+   line_change(0, #prev_lines, #curr_lines)
 end
 
-function M.apply_delta(buffer, delta)
-    local text_edits = teamtype_delta_to_lsp_text_edits(delta)
+function M.apply_delta (buffer, delta)
+   local text_edits = teamtype_delta_to_lsp_text_edits(delta)
 
-    ignore_edits = true
-    lsp_util.apply_text_edits(text_edits, buffer, "utf-32")
-    ignore_edits = false
+   ignore_edits = true
+   lsp_util.apply_text_edits(text_edits, buffer, "utf-32")
+   ignore_edits = false
 end
 
 return M

--- a/nvim-plugin/lua/teamtype/connection.lua
+++ b/nvim-plugin/lua/teamtype/connection.lua
@@ -8,66 +8,66 @@ local M = {}
 -- A Connection represents an active JSON-RPC connection.
 local Connection = {}
 
-function Connection:is_connected()
-    return self.connection ~= nil
+function Connection:is_connected ()
+   return self.connection ~= nil
 end
 
-function Connection:send_notification(method, params)
-    self.connection.notify(method, params)
+function Connection:send_notification (method, params)
+   self.connection.notify(method, params)
 end
 
-function Connection:send_request(method, params, result_callback, err_callback)
-    err_callback = err_callback or function() end
-    result_callback = result_callback or function() end
+function Connection:send_request (method, params, result_callback, err_callback)
+   err_callback = err_callback or function () end
+   result_callback = result_callback or function () end
 
-    self.connection.request(method, params, function(err, result)
-        if err then
-            local error_msg = "[teamtype] Error for '" .. method .. "': " .. err.message
-            if err.data and err.data ~= "" then
-                error_msg = error_msg .. " (" .. err.data .. ")"
-            end
-            vim.api.nvim_err_writeln(error_msg)
-            err_callback(err)
-        end
-        if result then
-            result_callback(result)
-        end
-    end)
+   self.connection.request(method, params, function (err, result)
+      if err then
+         local error_msg = "[teamtype] Error for '" .. method .. "': " .. err.message
+         if err.data and err.data ~= "" then
+            error_msg = error_msg .. " (" .. err.data .. ")"
+         end
+         vim.api.nvim_err_writeln(error_msg)
+         err_callback(err)
+      end
+      if result then
+         result_callback(result)
+      end
+   end)
 end
 
 -- Connect to the daemon, and return a handle on the connection.
-function M.connect(cmd, directory, dispatchers)
-    local executable = cmd[1]
-    if vim.fn.executable(executable) == 0 then
-        vim.api.nvim_err_writeln(
-            "Tried to connect to the Teamtype daemon, but `"
-                .. executable
-                .. "` executable was not found. Make sure that is in your PATH."
-        )
-        return nil
-    end
+function M.connect (cmd, directory, dispatchers)
+   local executable = cmd[1]
+   if vim.fn.executable(executable) == 0 then
+      vim.api.nvim_err_writeln(
+         "Tried to connect to the Teamtype daemon, but `"
+            .. executable
+            .. "` executable was not found. Make sure that is in your PATH."
+      )
+      return nil
+   end
 
-    local connection
-    local extra_spawn_params = { cwd = directory }
+   local connection
+   local extra_spawn_params = { cwd = directory }
 
-    if vim.version().api_level < 12 then
-        -- In Neovim 0.9, the API was to pass the command and its parameters as two arguments.
-        local params = {}
-        for i = 2, #cmd do
-            table.insert(params, cmd[i])
-        end
-        ---@diagnostic disable-next-line: redundant-parameter
-        connection = vim.lsp.rpc.start(executable, params, dispatchers, extra_spawn_params)
-    else
-        -- While in Neovim 0.10, it is combined into one table.
-        connection = vim.lsp.rpc.start(cmd, dispatchers, extra_spawn_params)
-    end
+   if vim.version().api_level < 12 then
+      -- In Neovim 0.9, the API was to pass the command and its parameters as two arguments.
+      local params = {}
+      for i = 2, #cmd do
+         table.insert(params, cmd[i])
+      end
+      ---@diagnostic disable-next-line: redundant-parameter
+      connection = vim.lsp.rpc.start(executable, params, dispatchers, extra_spawn_params)
+   else
+      -- While in Neovim 0.10, it is combined into one table.
+      connection = vim.lsp.rpc.start(cmd, dispatchers, extra_spawn_params)
+   end
 
-    print("Connected to Teamtype daemon!")
+   print("Connected to Teamtype daemon!")
 
-    local result = { connection = connection }
-    setmetatable(result, { __index = Connection })
-    return result
+   local result = { connection = connection }
+   setmetatable(result, { __index = Connection })
+   return result
 end
 
 return M

--- a/nvim-plugin/lua/teamtype/cursor.lua
+++ b/nvim-plugin/lua/teamtype/cursor.lua
@@ -24,403 +24,403 @@ local following_user_id = nil
 -- keeps track across ModeChanged events whether the last mode was visual
 local was_visual_selection = nil
 
-local function show_cursor_information(name, cursor)
-    return (name or "Unknown user") .. " @ " .. vim.uri_to_fname(cursor.uri) .. ":" .. cursor.range.start.line + 1
+local function show_cursor_information (name, cursor)
+   return (name or "Unknown user") .. " @ " .. vim.uri_to_fname(cursor.uri) .. ":" .. cursor.range.start.line + 1
 end
 
 -- https://www.reddit.com/r/neovim/comments/152bs5t/unable_to_render_comments_in_the_color_id_like/
 vim.api.nvim_create_autocmd("ColorScheme", {
-    pattern = "*",
-    callback = function()
-        vim.api.nvim_set_hl(0, "TeamtypeUsername", { fg = "#808080", ctermfg = 12 })
-    end,
+   pattern = "*",
+   callback = function ()
+      vim.api.nvim_set_hl(0, "TeamtypeUsername", { fg = "#808080", ctermfg = 12 })
+   end,
 })
 vim.api.nvim_exec_autocmds("ColorScheme", {})
 
-local function is_forward(start_row, end_row, start_col, end_col)
-    return (start_row < end_row) or (start_row == end_row and start_col <= end_col)
+local function is_forward (start_row, end_row, start_col, end_col)
+   return (start_row < end_row) or (start_row == end_row and start_col <= end_col)
 end
 
-local function jump_to_user_id(user_id)
-    local cursors = user_cursors[user_id].cursors
-    local cursor = cursors[#cursors]
-    if cursor == nil then
-        following_user_id = nil
-    else
-        local location = {
-            targetUri = cursor.uri,
-            targetRange = cursor.range,
-            targetSelectionRange = cursor.range,
-        }
-        -- In Neovim 0.11, jump_to_location was deprecated.
-        if vim.version().api_level < 13 then
-            vim.lsp.util.jump_to_location(location, offset_encoding, true)
-        else
-            vim.lsp.util.show_document(location, offset_encoding)
-        end
-    end
+local function jump_to_user_id (user_id)
+   local cursors = user_cursors[user_id].cursors
+   local cursor = cursors[#cursors]
+   if cursor == nil then
+      following_user_id = nil
+   else
+      local location = {
+         targetUri = cursor.uri,
+         targetRange = cursor.range,
+         targetSelectionRange = cursor.range,
+      }
+      -- In Neovim 0.11, jump_to_location was deprecated.
+      if vim.version().api_level < 13 then
+         vim.lsp.util.jump_to_location(location, offset_encoding, true)
+      else
+         vim.lsp.util.show_document(location, offset_encoding)
+      end
+   end
 end
 
 -- A new set of ranges means, we delete all existing ones for that user.
-function M.set_cursor(uri, user_id, name, ranges)
-    -- Find correct buffer to apply edits to.
-    local bufnr = vim.uri_to_bufnr(uri)
+function M.set_cursor (uri, user_id, name, ranges)
+   -- Find correct buffer to apply edits to.
+   local bufnr = vim.uri_to_bufnr(uri)
 
-    if user_cursors[user_id] then
-        for _, user_cursor in ipairs(user_cursors[user_id].cursors) do
-            if user_cursor.extmark then
-                local old_id = user_cursor.extmark.id
-                local old_bufnr = user_cursor.extmark.bufnr
-                vim.api.nvim_buf_del_extmark(old_bufnr, cursor_namespace, old_id)
+   if user_cursors[user_id] then
+      for _, user_cursor in ipairs(user_cursors[user_id].cursors) do
+         if user_cursor.extmark then
+            local old_id = user_cursor.extmark.id
+            local old_bufnr = user_cursor.extmark.bufnr
+            vim.api.nvim_buf_del_extmark(old_bufnr, cursor_namespace, old_id)
+         end
+      end
+   end
+   user_cursors[user_id] = { name = name, cursors = {} }
+
+   if not vim.api.nvim_buf_is_loaded(bufnr) then
+      -- TODO: Should we also implement a timeout here?
+      for _, range in ipairs(ranges) do
+         table.insert(user_cursors[user_id].cursors, { uri = uri, range = range, extmark = nil })
+      end
+   else
+      for i, range in ipairs(ranges) do
+         -- Convert from LSP style ranges to Neovim style ranges.
+         local start_row = range.start.line
+         local start_col = vim.lsp.util._get_line_byte_from_position(bufnr, range.start, offset_encoding)
+         local end_row = range["end"].line
+         local end_col = vim.lsp.util._get_line_byte_from_position(bufnr, range["end"], offset_encoding)
+
+         -- If the range is backwards, swap the start and end positions.
+         if not is_forward(start_row, end_row, start_col, end_col) then
+            start_row, end_row = end_row, start_row
+            start_col, end_col = end_col, start_col
+         end
+
+         -- If the range is empty, expand the highlighted range by 1 to make it visible.
+         if start_row == end_row and start_col == end_col then
+            local bytes_in_end_row = vim.fn.strlen(vim.fn.getline(end_row + 1))
+            if bytes_in_end_row > end_col then
+               -- Note: Instead of 1, we should actually add the byte length of the character at this position.
+               end_col = end_col + 1
+            elseif bytes_in_end_row > 0 then
+               -- This highlights the last character in the row.
+               start_col = start_col - 1
             end
-        end
-    end
-    user_cursors[user_id] = { name = name, cursors = {} }
+         end
 
-    if not vim.api.nvim_buf_is_loaded(bufnr) then
-        -- TODO: Should we also implement a timeout here?
-        for _, range in ipairs(ranges) do
-            table.insert(user_cursors[user_id].cursors, { uri = uri, range = range, extmark = nil })
-        end
-    else
-        for i, range in ipairs(ranges) do
-            -- Convert from LSP style ranges to Neovim style ranges.
-            local start_row = range.start.line
-            local start_col = vim.lsp.util._get_line_byte_from_position(bufnr, range.start, offset_encoding)
-            local end_row = range["end"].line
-            local end_col = vim.lsp.util._get_line_byte_from_position(bufnr, range["end"], offset_encoding)
+         local e = {
+            start_row = start_row,
+            start_col = start_col,
+            end_row = end_row,
+            end_col = end_col,
+         }
 
-            -- If the range is backwards, swap the start and end positions.
-            if not is_forward(start_row, end_row, start_col, end_col) then
-                start_row, end_row = end_row, start_row
-                start_col, end_col = end_col, start_col
-            end
+         local virt_text = {}
+         if i == 1 and name then
+            virt_text = { { name, "TeamtypeUsername" } }
+         end
 
-            -- If the range is empty, expand the highlighted range by 1 to make it visible.
-            if start_row == end_row and start_col == end_col then
-                local bytes_in_end_row = vim.fn.strlen(vim.fn.getline(end_row + 1))
-                if bytes_in_end_row > end_col then
-                    -- Note: Instead of 1, we should actually add the byte length of the character at this position.
-                    end_col = end_col + 1
-                elseif bytes_in_end_row > 0 then
-                    -- This highlights the last character in the row.
-                    start_col = start_col - 1
-                end
-            end
+         -- Try setting the extmark, ignore errors (which can happen at end of lines/buffers).
+         pcall(function ()
+            local extmark_id = vim.api.nvim_buf_set_extmark(bufnr, cursor_namespace, e.start_row, e.start_col, {
+               hl_mode = "combine",
+               hl_group = "TermCursor",
+               end_col = e.end_col,
+               end_row = e.end_row,
+               virt_text = virt_text,
+            })
+            vim.defer_fn(function ()
+               vim.api.nvim_buf_del_extmark(bufnr, cursor_namespace, extmark_id)
+               for _, user_cursor in ipairs(user_cursors[user_id].cursors) do
+                  if user_cursor.extmark ~= nil and user_cursor.extmark.id == extmark_id then
+                     -- If we find our own extmark_id, we can remove all ranges,
+                     -- because they were all created at the same time.
+                     user_cursors[user_id].cursors = {}
+                     break
+                  end
+               end
+            end, cursor_timeout_ms)
 
-            local e = {
-                start_row = start_row,
-                start_col = start_col,
-                end_row = end_row,
-                end_col = end_col,
-            }
-
-            local virt_text = {}
-            if i == 1 and name then
-                virt_text = { { name, "TeamtypeUsername" } }
-            end
-
-            -- Try setting the extmark, ignore errors (which can happen at end of lines/buffers).
-            pcall(function()
-                local extmark_id = vim.api.nvim_buf_set_extmark(bufnr, cursor_namespace, e.start_row, e.start_col, {
-                    hl_mode = "combine",
-                    hl_group = "TermCursor",
-                    end_col = e.end_col,
-                    end_row = e.end_row,
-                    virt_text = virt_text,
-                })
-                vim.defer_fn(function()
-                    vim.api.nvim_buf_del_extmark(bufnr, cursor_namespace, extmark_id)
-                    for _, user_cursor in ipairs(user_cursors[user_id].cursors) do
-                        if user_cursor.extmark ~= nil and user_cursor.extmark.id == extmark_id then
-                            -- If we find our own extmark_id, we can remove all ranges,
-                            -- because they were all created at the same time.
-                            user_cursors[user_id].cursors = {}
-                            break
-                        end
-                    end
-                end, cursor_timeout_ms)
-
-                table.insert(
-                    user_cursors[user_id].cursors,
-                    { uri = uri, range = range, extmark = { id = extmark_id, bufnr = bufnr } }
-                )
-            end)
-        end
-    end
-    if following_user_id == user_id then
-        jump_to_user_id(user_id)
-    end
+            table.insert(
+               user_cursors[user_id].cursors,
+               { uri = uri, range = range, extmark = { id = extmark_id, bufnr = bufnr } }
+            )
+         end)
+      end
+   end
+   if following_user_id == user_id then
+      jump_to_user_id(user_id)
+   end
 end
 
-function M.track_cursor(bufnr, callback)
-    vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI", "ModeChanged" }, {
-        buffer = bufnr,
-        callback = function(ev)
-            local ranges = {}
+function M.track_cursor (bufnr, callback)
+   vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI", "ModeChanged" }, {
+      buffer = bufnr,
+      callback = function (ev)
+         local ranges = {}
 
-            -- TODO: Split this code into multiple functions.
-            local visual_selection = vim.fn.mode() == "v" or vim.fn.mode() == "V" or vim.fn.mode() == ""
+         -- TODO: Split this code into multiple functions.
+         local visual_selection = vim.fn.mode() == "v" or vim.fn.mode() == "V" or vim.fn.mode() == ""
 
-            -- We only care about "ModeChanged" if we were in visual mode to clear the range seen by the peer.
-            if ev.event == "ModeChanged" and not was_visual_selection then
-                return
+         -- We only care about "ModeChanged" if we were in visual mode to clear the range seen by the peer.
+         if ev.event == "ModeChanged" and not was_visual_selection then
+            return
+         end
+         was_visual_selection = visual_selection
+
+         if visual_selection then
+            -- This is the "active end" that the protocol talks about.
+            local end_row, end_col = unpack(vim.api.nvim_win_get_cursor(0))
+            -- Whereas this corresponds the the "anchor" in other range data structures.
+            local _, start_row, start_col = unpack(vim.fn.getpos("v"))
+
+            -- When using getpos(), the column is 1-indexed, but we want it to be 0-indexed.
+            start_col = start_col - 1
+
+            if vim.fn.mode() == "v" then
+               -- TODO: This is not in "screen columns", but in "bytes"!
+               if not is_forward(start_row, end_row, start_col, end_col) then
+                  -- If the selection is backwards, we need to extend it on both ends for some reason.
+                  end_col = end_col - 1
+                  start_col = start_col + 1
+               end
+            elseif vim.fn.mode() == "V" then
+               -- If we're in linewise visual mode, expand the range to include the entire line(s).
+               if is_forward(start_row, end_row, start_col, end_col) then
+                  start_col = 0
+                  end_col = vim.fn.strlen(vim.fn.getline(end_row)) - 1
+               else
+                  start_col = vim.fn.strlen(vim.fn.getline(start_row))
+                  end_col = -1
+               end
             end
-            was_visual_selection = visual_selection
 
-            if visual_selection then
-                -- This is the "active end" that the protocol talks about.
-                local end_row, end_col = unpack(vim.api.nvim_win_get_cursor(0))
-                -- Whereas this corresponds the the "anchor" in other range data structures.
-                local _, start_row, start_col = unpack(vim.fn.getpos("v"))
+            if vim.fn.mode() == "v" or vim.fn.mode() == "V" then
+               local range = vim.lsp.util.make_given_range_params(
+                  { start_row, start_col },
+                  { end_row, end_col },
+                  bufnr,
+                  offset_encoding
+               ).range
+               ranges = { range }
+            elseif vim.fn.mode() == "" then
+               -- We are in blockwise visual mode. Calculate the individual pieces.
 
-                -- When using getpos(), the column is 1-indexed, but we want it to be 0-indexed.
-                start_col = start_col - 1
+               -- This calculation is a bit more involved, because Neovim forms a blockwise range visually, going by the
+               -- "display cells", so that the range is always rectangular. We need to perform our own calculations with
+               -- these display cells to make sure that we send out the same ranges.
 
-                if vim.fn.mode() == "v" then
-                    -- TODO: This is not in "screen columns", but in "bytes"!
-                    if not is_forward(start_row, end_row, start_col, end_col) then
-                        -- If the selection is backwards, we need to extend it on both ends for some reason.
-                        end_col = end_col - 1
-                        start_col = start_col + 1
-                    end
-                elseif vim.fn.mode() == "V" then
-                    -- If we're in linewise visual mode, expand the range to include the entire line(s).
-                    if is_forward(start_row, end_row, start_col, end_col) then
-                        start_col = 0
-                        end_col = vim.fn.strlen(vim.fn.getline(end_row)) - 1
-                    else
-                        start_col = vim.fn.strlen(vim.fn.getline(start_row))
-                        end_col = -1
-                    end
-                end
+               -- TODO: There are still some inconsistencies; when the cursor is inside a multi-column character, other lines might be too short.
 
-                if vim.fn.mode() == "v" or vim.fn.mode() == "V" then
-                    local range = vim.lsp.util.make_given_range_params(
-                        { start_row, start_col },
-                        { end_row, end_col },
+               -- At this point, start_col and end_col are zero-indexed, in bytes, and related to the position in front of the cursor.
+
+               local start_line = vim.fn.getline(start_row)
+               local end_line = vim.fn.getline(end_row)
+
+               local string_to_start = string.sub(start_line, 0, start_col)
+               local string_to_end = string.sub(end_line, 0, end_col)
+
+               -- These are the widths of the strings in "display cells".
+               local cells_to_start = vim.fn.strdisplaywidth(string_to_start)
+               local cells_to_end = vim.fn.strdisplaywidth(string_to_end)
+
+               local smaller_cell = math.min(cells_to_start, cells_to_end)
+               local larger_cell = math.max(cells_to_start, cells_to_end)
+
+               local smaller_row = math.min(start_row, end_row)
+               local larger_row = math.max(start_row, end_row)
+
+               for row = smaller_row, larger_row do
+                  local bytes_start = vim.fn.virtcol2col(bufnr, row, smaller_cell + 1) - 1
+                  local bytes_end = vim.fn.virtcol2col(bufnr, row, larger_cell + 1) - 1
+
+                  if bytes_start ~= -1 then
+                     -- The line is not empty, add a range.
+                     local range = vim.lsp.util.make_given_range_params(
+                        { row, bytes_start },
+                        { row, bytes_end },
                         bufnr,
                         offset_encoding
-                    ).range
-                    ranges = { range }
-                elseif vim.fn.mode() == "" then
-                    -- We are in blockwise visual mode. Calculate the individual pieces.
-
-                    -- This calculation is a bit more involved, because Neovim forms a blockwise range visually, going by the
-                    -- "display cells", so that the range is always rectangular. We need to perform our own calculations with
-                    -- these display cells to make sure that we send out the same ranges.
-
-                    -- TODO: There are still some inconsistencies; when the cursor is inside a multi-column character, other lines might be too short.
-
-                    -- At this point, start_col and end_col are zero-indexed, in bytes, and related to the position in front of the cursor.
-
-                    local start_line = vim.fn.getline(start_row)
-                    local end_line = vim.fn.getline(end_row)
-
-                    local string_to_start = string.sub(start_line, 0, start_col)
-                    local string_to_end = string.sub(end_line, 0, end_col)
-
-                    -- These are the widths of the strings in "display cells".
-                    local cells_to_start = vim.fn.strdisplaywidth(string_to_start)
-                    local cells_to_end = vim.fn.strdisplaywidth(string_to_end)
-
-                    local smaller_cell = math.min(cells_to_start, cells_to_end)
-                    local larger_cell = math.max(cells_to_start, cells_to_end)
-
-                    local smaller_row = math.min(start_row, end_row)
-                    local larger_row = math.max(start_row, end_row)
-
-                    for row = smaller_row, larger_row do
-                        local bytes_start = vim.fn.virtcol2col(bufnr, row, smaller_cell + 1) - 1
-                        local bytes_end = vim.fn.virtcol2col(bufnr, row, larger_cell + 1) - 1
-
-                        if bytes_start ~= -1 then
-                            -- The line is not empty, add a range.
-                            local range = vim.lsp.util.make_given_range_params(
-                                { row, bytes_start },
-                                { row, bytes_end },
-                                bufnr,
-                                offset_encoding
-                            ).range
-                            table.insert(ranges, range)
-                        end
-                    end
-                end
-            else
-                local range = vim.lsp.util.make_range_params(0, offset_encoding).range
-                ranges = { range }
+                     ).range
+                     table.insert(ranges, range)
+                  end
+               end
             end
+         else
+            local range = vim.lsp.util.make_range_params(0, offset_encoding).range
+            ranges = { range }
+         end
 
-            callback(ranges)
-        end,
-    })
-    -- Trigger the callback above once, to send initial cursor position.
-    vim.api.nvim_exec_autocmds("CursorMoved", {})
+         callback(ranges)
+      end,
+   })
+   -- Trigger the callback above once, to send initial cursor position.
+   vim.api.nvim_exec_autocmds("CursorMoved", {})
 end
 
 local on_key_nsid = nil
-local function unfollow_cursor()
-    if following_user_id ~= nil then
-        print("Unfollowed cursor")
-        following_user_id = nil
-        vim.on_key(nil, on_key_nsid)
-    end
+local function unfollow_cursor ()
+   if following_user_id ~= nil then
+      print("Unfollowed cursor")
+      following_user_id = nil
+      vim.on_key(nil, on_key_nsid)
+   end
 end
 
-local function pick_cursor_menu(callback)
-    local users = {}
-    local descriptions = {}
-    local max_width = 10
-    local locations = {}
-    for user_id, data in pairs(user_cursors) do
-        local _, cursor = next(data.cursors)
-        if cursor then
-            local description = show_cursor_information(data.name, cursor)
-            local desc_width = vim.fn.strdisplaywidth(description)
-            if desc_width > max_width then
-                max_width = desc_width
-            end
+local function pick_cursor_menu (callback)
+   local users = {}
+   local descriptions = {}
+   local max_width = 10
+   local locations = {}
+   for user_id, data in pairs(user_cursors) do
+      local _, cursor = next(data.cursors)
+      if cursor then
+         local description = show_cursor_information(data.name, cursor)
+         local desc_width = vim.fn.strdisplaywidth(description)
+         if desc_width > max_width then
+            max_width = desc_width
+         end
 
-            table.insert(descriptions, description)
+         table.insert(descriptions, description)
 
-            table.insert(users, user_id)
-            table.insert(locations, {
-                targetUri = cursor.uri,
-                targetRange = cursor.range,
-                targetSelectionRange = cursor.range,
-            })
-        end
-    end
+         table.insert(users, user_id)
+         table.insert(locations, {
+            targetUri = cursor.uri,
+            targetRange = cursor.range,
+            targetSelectionRange = cursor.range,
+         })
+      end
+   end
 
-    if #users == 0 then
-        print("No cursor available.")
-    elseif #users == 1 then
-        callback(users[1])
-    else
-        local buf = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_buf_set_lines(buf, 0, -1, true, descriptions)
-        vim.bo[buf].modifiable = false
+   if #users == 0 then
+      print("No cursor available.")
+   elseif #users == 1 then
+      callback(users[1])
+   else
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, true, descriptions)
+      vim.bo[buf].modifiable = false
 
-        local opts = {
-            relative = "cursor",
-            width = max_width,
-            height = #descriptions,
-            col = 0,
-            row = 1,
-            anchor = "NW",
-            style = "minimal",
-            border = "single",
-        }
-        local win = vim.api.nvim_open_win(buf, true, opts)
+      local opts = {
+         relative = "cursor",
+         width = max_width,
+         height = #descriptions,
+         col = 0,
+         row = 1,
+         anchor = "NW",
+         style = "minimal",
+         border = "single",
+      }
+      local win = vim.api.nvim_open_win(buf, true, opts)
 
-        vim.api.nvim_buf_set_keymap(buf, "n", "<CR>", "", {
-            callback = function()
-                local line_number = vim.fn.line(".")
-                vim.api.nvim_win_close(win, true)
-                callback(users[line_number])
-            end,
-        })
-        vim.api.nvim_buf_set_keymap(buf, "n", "<Esc>", "", {
-            callback = function()
-                vim.api.nvim_win_close(win, true)
-            end,
-        })
-        vim.api.nvim_create_autocmd("BufLeave", {
-            buffer = buf,
-            callback = function()
-                vim.api.nvim_win_close(win, true)
-            end,
-        })
-    end
+      vim.api.nvim_buf_set_keymap(buf, "n", "<CR>", "", {
+         callback = function ()
+            local line_number = vim.fn.line(".")
+            vim.api.nvim_win_close(win, true)
+            callback(users[line_number])
+         end,
+      })
+      vim.api.nvim_buf_set_keymap(buf, "n", "<Esc>", "", {
+         callback = function ()
+            vim.api.nvim_win_close(win, true)
+         end,
+      })
+      vim.api.nvim_create_autocmd("BufLeave", {
+         buffer = buf,
+         callback = function ()
+            vim.api.nvim_win_close(win, true)
+         end,
+      })
+   end
 end
 
-function M.follow_cursor()
-    local callback = function(user_id)
-        print("Following cursor")
-        jump_to_user_id(user_id)
-        following_user_id = user_id
+function M.follow_cursor ()
+   local callback = function (user_id)
+      print("Following cursor")
+      jump_to_user_id(user_id)
+      following_user_id = user_id
 
-        on_key_nsid = vim.on_key(function(_, typed)
-            -- {typed} may be empty if the first argument is produced by non-typed key(s) or by the same typed key(s) that produced a previous {key}
-            -- on_key is triggered even when the followee moves/types, but {typed} is empty in this case
-            if following_user_id ~= nil and typed ~= nil and typed ~= "" then
-                unfollow_cursor()
-            end
-        end)
-    end
-    pick_cursor_menu(callback)
+      on_key_nsid = vim.on_key(function (_, typed)
+         -- {typed} may be empty if the first argument is produced by non-typed key(s) or by the same typed key(s) that produced a previous {key}
+         -- on_key is triggered even when the followee moves/types, but {typed} is empty in this case
+         if following_user_id ~= nil and typed ~= nil and typed ~= "" then
+            unfollow_cursor()
+         end
+      end)
+   end
+   pick_cursor_menu(callback)
 end
 
-function M.jump_to_cursor()
-    local callback = function(user_id)
-        jump_to_user_id(user_id)
-    end
-    pick_cursor_menu(callback)
+function M.jump_to_cursor ()
+   local callback = function (user_id)
+      jump_to_user_id(user_id)
+   end
+   pick_cursor_menu(callback)
 end
 
-function M.number_of_cursors()
-    local count = 0
-    for _, v in pairs(user_cursors) do
-        if #v.cursors > 0 then
-            count = count + 1
-        end
-    end
-    return count
+function M.number_of_cursors ()
+   local count = 0
+   for _, v in pairs(user_cursors) do
+      if #v.cursors > 0 then
+         count = count + 1
+      end
+   end
+   return count
 end
 
 -- Returns a description of remote cursors that are known to us.
-function M.short_cursor_description()
-    local users = {}
+function M.short_cursor_description ()
+   local users = {}
 
-    -- Build a structure using the values as keys, so they are de-duplicated.
-    for _, data in pairs(user_cursors) do
-        if #data.cursors > 0 then
-            if not users[data.name] then
-                users[data.name] = {}
-            end
-            for _, c in ipairs(data.cursors) do
-                users[data.name][vim.fs.basename(c.uri)] = true
-            end
-        end
-    end
+   -- Build a structure using the values as keys, so they are de-duplicated.
+   for _, data in pairs(user_cursors) do
+      if #data.cursors > 0 then
+         if not users[data.name] then
+            users[data.name] = {}
+         end
+         for _, c in ipairs(data.cursors) do
+            users[data.name][vim.fs.basename(c.uri)] = true
+         end
+      end
+   end
 
-    -- Now, build a string that we can return.
-    local user_list = {}
+   -- Now, build a string that we can return.
+   local user_list = {}
 
-    for name, files in pairs(users) do
-        local file_list = {}
+   for name, files in pairs(users) do
+      local file_list = {}
 
-        for file, _ in pairs(files) do
-            table.insert(file_list, file)
-        end
+      for file, _ in pairs(files) do
+         table.insert(file_list, file)
+      end
 
-        table.insert(user_list, name .. " (" .. table.concat(file_list, ", ") .. ")")
-    end
+      table.insert(user_list, name .. " (" .. table.concat(file_list, ", ") .. ")")
+   end
 
-    return table.concat(user_list, ", ")
+   return table.concat(user_list, ", ")
 end
 
-function M.list_cursors()
-    local message = ""
+function M.list_cursors ()
+   local message = ""
 
-    if next(user_cursors) == nil then
-        message = "No cursors."
-    else
-        for _, data in pairs(user_cursors) do
-            local name = data.name
-            local cursors = data.cursors
-            message = message .. (name or "") .. ":"
-            if #cursors == 0 then
-                message = message .. " No cursors"
-            elseif #cursors == 1 then
-                message = show_cursor_information(name, cursors[1])
-            else
-                message = message .. " Multiple cursors in " .. vim.uri_to_fname(cursors[1].uri)
-            end
-        end
-    end
+   if next(user_cursors) == nil then
+      message = "No cursors."
+   else
+      for _, data in pairs(user_cursors) do
+         local name = data.name
+         local cursors = data.cursors
+         message = message .. (name or "") .. ":"
+         if #cursors == 0 then
+            message = message .. " No cursors"
+         elseif #cursors == 1 then
+            message = show_cursor_information(name, cursors[1])
+         else
+            message = message .. " Multiple cursors in " .. vim.uri_to_fname(cursors[1].uri)
+         end
+      end
+   end
 
-    return message
+   return message
 end
 
 return M

--- a/nvim-plugin/lua/teamtype/cursor.lua
+++ b/nvim-plugin/lua/teamtype/cursor.lua
@@ -1,6 +1,7 @@
 -- SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 -- SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
 -- SPDX-FileCopyrightText: 2025 mbitard <code@bitard.fr>
+-- SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 --
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -159,15 +160,15 @@ function M.track_cursor(bufnr, callback)
             local ranges = {}
 
             -- TODO: Split this code into multiple functions.
-            local visualSelection = vim.fn.mode() == "v" or vim.fn.mode() == "V" or vim.fn.mode() == ""
+            local visual_selection = vim.fn.mode() == "v" or vim.fn.mode() == "V" or vim.fn.mode() == ""
 
             -- We only care about "ModeChanged" if we were in visual mode to clear the range seen by the peer.
             if ev.event == "ModeChanged" and not was_visual_selection then
                 return
             end
-            was_visual_selection = visualSelection
+            was_visual_selection = visual_selection
 
-            if visualSelection then
+            if visual_selection then
                 -- This is the "active end" that the protocol talks about.
                 local end_row, end_col = unpack(vim.api.nvim_win_get_cursor(0))
                 -- Whereas this corresponds the the "anchor" in other range data structures.

--- a/nvim-plugin/lua/teamtype/helpers.lua
+++ b/nvim-plugin/lua/teamtype/helpers.lua
@@ -1,5 +1,6 @@
 -- SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
 -- SPDX-FileCopyrightText: 2025 zormit <nt4u@kpvn.de>
+-- SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 --
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -14,12 +15,12 @@ function M.find_directory(filename, marker)
             if vim.fn.isdirectory(path .. "/" .. marker) == 1 then
                 return path
             end
-            local parentPath = vim.fn.fnamemodify(path, ":h")
-            if parentPath == path then
+            local parent_path = vim.fn.fnamemodify(path, ":h")
+            if parent_path == path then
                 -- We can't progress further like this.
                 return nil
             else
-                path = parentPath
+                path = parent_path
             end
         end
     else

--- a/nvim-plugin/lua/teamtype/helpers.lua
+++ b/nvim-plugin/lua/teamtype/helpers.lua
@@ -7,26 +7,26 @@
 local M = {}
 
 -- Recursively scan up directories. If we find a .teamtype directory on any level, return its parent, and nil otherwise.
-function M.find_directory(filename, marker)
-    if vim.version().api_level < 12 then
-        -- In Neovim 0.9, do it manually.
-        local path = filename
-        while true do
-            if vim.fn.isdirectory(path .. "/" .. marker) == 1 then
-                return path
-            end
-            local parent_path = vim.fn.fnamemodify(path, ":h")
-            if parent_path == path then
-                -- We can't progress further like this.
-                return nil
-            else
-                path = parent_path
-            end
-        end
-    else
-        -- In Neovim 0.10, this function is available.
-        return vim.fs.root(filename, marker)
-    end
+function M.find_directory (filename, marker)
+   if vim.version().api_level < 12 then
+      -- In Neovim 0.9, do it manually.
+      local path = filename
+      while true do
+         if vim.fn.isdirectory(path .. "/" .. marker) == 1 then
+            return path
+         end
+         local parent_path = vim.fn.fnamemodify(path, ":h")
+         if parent_path == path then
+            -- We can't progress further like this.
+            return nil
+         else
+            path = parent_path
+         end
+      end
+   else
+      -- In Neovim 0.10, this function is available.
+      return vim.fs.root(filename, marker)
+   end
 end
 
 return M

--- a/nvim-plugin/lua/teamtype/logging.lua
+++ b/nvim-plugin/lua/teamtype/logging.lua
@@ -7,27 +7,27 @@ local M = {}
 
 local logfile = os.getenv("TEAMTYPE_NVIM_LOGFILE")
 if logfile then
-    M._log_file_handle = io.open(logfile, "a")
+   M._log_file_handle = io.open(logfile, "a")
 end
 
-function M.debug(value)
-    if not M._log_file_handle then
-        return
-    end
+function M.debug (value)
+   if not M._log_file_handle then
+      return
+   end
 
-    if type(value) ~= "string" then
-        value = vim.inspect(value)
-    end
+   if type(value) ~= "string" then
+      value = vim.inspect(value)
+   end
 
-    local date = os.date("%Y-%m-%d %H:%M:%S")
-    local debug_info = debug.getinfo(2)
+   local date = os.date("%Y-%m-%d %H:%M:%S")
+   local debug_info = debug.getinfo(2)
 
-    local name = debug_info.name or "?"
-    local line = debug_info.currentline or "?"
-    local context = " " .. name .. ":" .. line
+   local name = debug_info.name or "?"
+   local line = debug_info.currentline or "?"
+   local context = " " .. name .. ":" .. line
 
-    M._log_file_handle:write(date .. context .. ": " .. value .. "\n")
-    M._log_file_handle:flush()
+   M._log_file_handle:write(date .. context .. ": " .. value .. "\n")
+   M._log_file_handle:flush()
 end
 
 return M

--- a/nvim-plugin/lua/teamtype/lsp_util.lua
+++ b/nvim-plugin/lua/teamtype/lsp_util.lua
@@ -12,14 +12,14 @@ local M = {}
 ---@param bufnr integer bufnr to get the lines from
 ---@param rows integer[] zero-indexed line numbers
 ---@return table<integer, string>|string a table mapping rows to lines
-local function get_lines(bufnr, rows)
-    rows = type(rows) == "table" and rows or { rows }
+local function get_lines (bufnr, rows)
+   rows = type(rows) == "table" and rows or { rows }
 
-    local lines = {}
-    for _, row in ipairs(rows) do
-        lines[row] = (vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false) or { "" })[1]
-    end
-    return lines
+   local lines = {}
+   for _, row in ipairs(rows) do
+      lines[row] = (vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false) or { "" })[1]
+   end
+   return lines
 end
 
 --- Gets the zero-indexed line from the given buffer.
@@ -29,8 +29,8 @@ end
 ---@param bufnr integer
 ---@param row integer zero-indexed line number
 ---@return string the line at row in filename
-local function get_line(bufnr, row)
-    return get_lines(bufnr, { row })[row]
+local function get_line (bufnr, row)
+   return get_lines(bufnr, { row })[row]
 end
 
 --- Applies a list of text edits to a buffer.
@@ -38,135 +38,131 @@ end
 ---@param bufnr integer Buffer id
 ---@param offset_encoding string utf-8|utf-16|utf-32
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textEdit
-function M.apply_text_edits(text_edits, bufnr, offset_encoding)
-    vim.validate({
-        text_edits = { text_edits, "t", false },
-        bufnr = { bufnr, "number", false },
-        offset_encoding = { offset_encoding, "string", false },
-    })
-    if not next(text_edits) then
-        return
-    end
+function M.apply_text_edits (text_edits, bufnr, offset_encoding)
+   vim.validate({
+      text_edits = { text_edits, "t", false },
+      bufnr = { bufnr, "number", false },
+      offset_encoding = { offset_encoding, "string", false },
+   })
+   if not next(text_edits) then
+      return
+   end
 
-    vim.bo[bufnr].buflisted = true
+   vim.bo[bufnr].buflisted = true
 
-    -- Fix reversed range and indexing each text_edits
-    local index = 0
-    text_edits = vim.tbl_map(function(text_edit)
-        index = index + 1
-        text_edit._index = index
+   -- Fix reversed range and indexing each text_edits
+   local index = 0
+   text_edits = vim.tbl_map(function (text_edit)
+      index = index + 1
+      text_edit._index = index
 
-        if
-            text_edit.range.start.line > text_edit.range["end"].line
-            or text_edit.range.start.line == text_edit.range["end"].line
-                and text_edit.range.start.character > text_edit.range["end"].character
-        then
-            local start = text_edit.range.start
-            text_edit.range.start = text_edit.range["end"]
-            text_edit.range["end"] = start
-        end
-        return text_edit
-    end, text_edits)
+      if
+         text_edit.range.start.line > text_edit.range["end"].line
+         or text_edit.range.start.line == text_edit.range["end"].line
+            and text_edit.range.start.character > text_edit.range["end"].character
+      then
+         local start = text_edit.range.start
+         text_edit.range.start = text_edit.range["end"]
+         text_edit.range["end"] = start
+      end
+      return text_edit
+   end, text_edits)
 
-    -- Sort text_edits
-    table.sort(text_edits, function(a, b)
-        if a.range.start.line ~= b.range.start.line then
-            return a.range.start.line > b.range.start.line
-        end
-        if a.range.start.character ~= b.range.start.character then
-            return a.range.start.character > b.range.start.character
-        end
-        if a._index ~= b._index then
-            return a._index > b._index
-        end
-    end)
+   -- Sort text_edits
+   table.sort(text_edits, function (a, b)
+      if a.range.start.line ~= b.range.start.line then
+         return a.range.start.line > b.range.start.line
+      end
+      if a.range.start.character ~= b.range.start.character then
+         return a.range.start.character > b.range.start.character
+      end
+      if a._index ~= b._index then
+         return a._index > b._index
+      end
+   end)
 
-    -- save and restore local marks since they get deleted by nvim_buf_set_lines
-    local marks = {}
-    for _, m in pairs(vim.fn.getmarklist(bufnr)) do
-        if m.mark:match("^'[a-z]$") then
-            marks[m.mark:sub(2, 2)] = { m.pos[2], m.pos[3] - 1 } -- api-indexed
-        end
-    end
+   -- save and restore local marks since they get deleted by nvim_buf_set_lines
+   local marks = {}
+   for _, m in pairs(vim.fn.getmarklist(bufnr)) do
+      if m.mark:match("^'[a-z]$") then
+         marks[m.mark:sub(2, 2)] = { m.pos[2], m.pos[3] - 1 } -- api-indexed
+      end
+   end
 
-    -- Apply text edits.
-    local disable_eol = false
-    for _, text_edit in ipairs(text_edits) do
-        -- Normalize line ending
-        text_edit.newText, _ = string.gsub(text_edit.newText, "\r\n?", "\n")
+   -- Apply text edits.
+   local disable_eol = false
+   for _, text_edit in ipairs(text_edits) do
+      -- Normalize line ending
+      text_edit.newText, _ = string.gsub(text_edit.newText, "\r\n?", "\n")
 
-        -- Convert from LSP style ranges to Neovim style ranges.
-        local e = {
-            start_row = text_edit.range.start.line,
-            start_col = vim.lsp.util._get_line_byte_from_position(bufnr, text_edit.range.start, offset_encoding),
-            end_row = text_edit.range["end"].line,
-            end_col = vim.lsp.util._get_line_byte_from_position(bufnr, text_edit.range["end"], offset_encoding),
-            text = vim.split(text_edit.newText, "\n", { plain = true }),
-        }
+      -- Convert from LSP style ranges to Neovim style ranges.
+      local e = {
+         start_row = text_edit.range.start.line,
+         start_col = vim.lsp.util._get_line_byte_from_position(bufnr, text_edit.range.start, offset_encoding),
+         end_row = text_edit.range["end"].line,
+         end_col = vim.lsp.util._get_line_byte_from_position(bufnr, text_edit.range["end"], offset_encoding),
+         text = vim.split(text_edit.newText, "\n", { plain = true }),
+      }
 
-        local max = vim.api.nvim_buf_line_count(bufnr)
-        -- If the whole edit is after the lines in the buffer we can simply add the new text to the end
-        -- of the buffer.
-        if max <= e.start_row then
-            -- If the replacement text ends with a newline, drop it - we're happy with keeping the implicit
-            -- newline at the end of the buffer (which we're assuming to be there, because we're getting
-            -- an insert *after* the visible lines.
-            -- TODO: Is this always correct?
-            if #e.text > 1 and e.text[#e.text] == "" then
-                table.remove(e.text)
+      local max = vim.api.nvim_buf_line_count(bufnr)
+      -- If the whole edit is after the lines in the buffer we can simply add the new text to the end
+      -- of the buffer.
+      if max <= e.start_row then
+         -- If the replacement text ends with a newline, drop it - we're happy with keeping the implicit
+         -- newline at the end of the buffer (which we're assuming to be there, because we're getting
+         -- an insert *after* the visible lines.
+         -- TODO: Is this always correct?
+         if #e.text > 1 and e.text[#e.text] == "" then
+            table.remove(e.text)
+         end
+         vim.api.nvim_buf_set_lines(bufnr, max, max, false, e.text)
+      else
+         local last_line_len = #(get_line(bufnr, math.min(e.end_row, max - 1)) or "")
+         -- Some LSP servers may return +1 range of the buffer content but nvim_buf_set_text can't
+         -- accept it so we should fix it here.
+         if max <= e.end_row then
+            e.end_row = max - 1
+            e.end_col = last_line_len
+            disable_eol = true
+            -- "a" + 'eol' + replace((0,1), (1,0), "") => "a" + 'noeol'
+            -- "a" + 'eol' + replace((0,1), (1,0), "\n\n") => "a\n\n" + 'noeol' (I guess?)
+         else
+            -- If the replacement is over the end of a line (i.e. e.end_col is out of bounds and the
+            -- replacement text ends with a newline We can likely assume that the replacement is assumed
+            -- to be meant to replace the newline with another newline and we need to make sure this
+            -- doesn't add an extra empty line. E.g. when the last line to be replaced contains a '\r'
+            -- in the file some servers (clangd on windows) will include that character in the line
+            -- while nvim_buf_set_text doesn't count it as part of the line.
+            if e.end_col > last_line_len and #text_edit.newText > 0 and string.sub(text_edit.newText, -1) == "\n" then
+               table.remove(e.text, #e.text)
             end
-            vim.api.nvim_buf_set_lines(bufnr, max, max, false, e.text)
-        else
-            local last_line_len = #(get_line(bufnr, math.min(e.end_row, max - 1)) or "")
-            -- Some LSP servers may return +1 range of the buffer content but nvim_buf_set_text can't
-            -- accept it so we should fix it here.
-            if max <= e.end_row then
-                e.end_row = max - 1
-                e.end_col = last_line_len
-                disable_eol = true
-                -- "a" + 'eol' + replace((0,1), (1,0), "") => "a" + 'noeol'
-                -- "a" + 'eol' + replace((0,1), (1,0), "\n\n") => "a\n\n" + 'noeol' (I guess?)
-            else
-                -- If the replacement is over the end of a line (i.e. e.end_col is out of bounds and the
-                -- replacement text ends with a newline We can likely assume that the replacement is assumed
-                -- to be meant to replace the newline with another newline and we need to make sure this
-                -- doesn't add an extra empty line. E.g. when the last line to be replaced contains a '\r'
-                -- in the file some servers (clangd on windows) will include that character in the line
-                -- while nvim_buf_set_text doesn't count it as part of the line.
-                if
-                    e.end_col > last_line_len
-                    and #text_edit.newText > 0
-                    and string.sub(text_edit.newText, -1) == "\n"
-                then
-                    table.remove(e.text, #e.text)
-                end
-            end
-            -- Make sure we don't go out of bounds for e.end_col
-            e.end_col = math.min(last_line_len, e.end_col)
+         end
+         -- Make sure we don't go out of bounds for e.end_col
+         e.end_col = math.min(last_line_len, e.end_col)
 
-            vim.api.nvim_buf_set_text(bufnr, e.start_row, e.start_col, e.end_row, e.end_col, e.text)
-        end
-    end
+         vim.api.nvim_buf_set_text(bufnr, e.start_row, e.start_col, e.end_row, e.end_col, e.text)
+      end
+   end
 
-    local max = vim.api.nvim_buf_line_count(bufnr)
+   local max = vim.api.nvim_buf_line_count(bufnr)
 
-    -- no need to restore marks that still exist
-    for _, m in pairs(vim.fn.getmarklist(bufnr)) do
-        marks[m.mark:sub(2, 2)] = nil
-    end
-    -- restore marks
-    for mark, pos in pairs(marks) do
-        if pos then
-            -- make sure we don't go out of bounds
-            pos[1] = math.min(pos[1], max)
-            pos[2] = math.min(pos[2], #(get_line(bufnr, pos[1] - 1) or ""))
-            vim.api.nvim_buf_set_mark(bufnr or 0, mark, pos[1], pos[2], {})
-        end
-    end
+   -- no need to restore marks that still exist
+   for _, m in pairs(vim.fn.getmarklist(bufnr)) do
+      marks[m.mark:sub(2, 2)] = nil
+   end
+   -- restore marks
+   for mark, pos in pairs(marks) do
+      if pos then
+         -- make sure we don't go out of bounds
+         pos[1] = math.min(pos[1], max)
+         pos[2] = math.min(pos[2], #(get_line(bufnr, pos[1] - 1) or ""))
+         vim.api.nvim_buf_set_mark(bufnr or 0, mark, pos[1], pos[2], {})
+      end
+   end
 
-    if disable_eol then
-        vim.bo.eol = false
-    end
+   if disable_eol then
+      vim.bo.eol = false
+   end
 end
 
 return M

--- a/nvim-plugin/plugin/teamtype.lua
+++ b/nvim-plugin/plugin/teamtype.lua
@@ -11,8 +11,8 @@ local teamtype = require("teamtype")
 local binary_name = os.getenv("TEAMTYPE_BINARY") or "teamtype"
 
 teamtype.config("teamtype", {
-    cmd = { binary_name, "client" },
-    root_markers = ".teamtype",
+   cmd = { binary_name, "client" },
+   root_markers = ".teamtype",
 })
 
 teamtype.enable("teamtype")


### PR DESCRIPTION
As noted [in this PR review comment](https://github.com/teamtype/teamtype/pull/427#discussion_r3330723372) the Lua identifier casing is slightly inconsistent. The first commit here fixes that. The remaining camelCase instates are table keys used externally by LSP and so forth.

After that this takes a quick dive into possible bikeshed territory. Please don't knock it till you try it!

1. Use a space between the identify and the signature when defining functions, and no space when calling them.

    Lua is very tolerant of whitespace variations. I have a strong preference for this particular combination in relation to function definitions and it is consistent with some other language defaults.

    ```lua
    -- Like this:
    function foo (arg) end
    foo(6)

    -- Never like this or other variants:
    function foo(arg) end
    foo (6)
    ```

2. Use 3-space indents.

   Yes three is an odd number, and yes very few language consider this normal. But Lua kind of does. Many large Lua code bases including many of the most used Lua ecosystem tools have standardized on this: `luarocks`, `luacheck`, `busted`, etc.

   Many rationals for this preference could be invented. I personally thought it was fantastically unorthodox when I was first exposed, then in quickly grew on me for Lua specifically. I don't think it works well for most languages, but it suites Lua nicely. Lua tends to have more deeply nested control structures than many languages; so 4 space indents tend to waste a lot of horizontal space but (IMO) 2 space indents don't give enough visual separation. 3 might be odd but it turns out to be a sweet spot. Many of the language constructs end up with a very satisfactory alignment:

    ```lua
    -- comment leaders are 3 spaces wide
    -- if conditionals with continuations like and/or line up with the initial expression
    if a == 1
       and b == 2
       or a == b
       then

       -- string concatenation operators are 3 wide
       local foo = "bob"
          .. a
          .. b

       -- Deep nesting doesn't eat too much space but is more distinct than 2 space:
       local bar = func({
          foo = "bar",
          nested = {
             foo = "bar",
             nested = {
                foo = "bar",
                nested = {
                   foo = "bar",
                },
             },
          },
       })

       -- ending nested control structures cascade
       for i in ipairs(_) do
          for j in ipairs(_)  do
             print(i, j)
          end
       end

    end
    ```

Obviously these last two changes are low priority and entirely based on my preferences, but having worked with a lot of Lua code I do suggest trying them on on for size.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
