### PR TITLE
Avoid messing with Cargo's default handling of profiles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/upload-rust-binary-action@v1
+        env:
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+          CARGO_PROFILE_RELEASE_LTO: fat
+          CARGO_PROFILE_RELEASE_STRIP: symbols
         with:
           bin: teamtype
           include: README.md,LICENSE.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,15 +38,6 @@ default-features = false
 [workspace.dependencies.teamtype]
 path = "crates/teamtype"
 
-# Stripping symbols (not debuginfo) reduces binary size by ~1.5x.
-# This is the default profile for `cargo install`:
-# https://doc.rust-lang.org/cargo/reference/profiles.html#profile-selection.
-# TODO: We may want to make [profile.release-size] the default
-# once we're out of the fast iteration development phase.
-[profile.release]
-strip = true
-opt-level = 3
-
 # The fuzzer in the e2e-tests crate will time out without optimizations enabled.
 # It is ignored by default, to run it one must use `cargo test --test fuzzer`.
 # Only the fuzzer tests actually time out without optimizations, and yes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,19 +47,6 @@ path = "crates/teamtype"
 strip = true
 opt-level = 3
 
-# 2-3x slower to compile, but produces a ~1.2x smaller binary.
-[profile.release-lto]
-inherits = "release"
-lto = true
-codegen-units = 1
-
-# Also quite slow to compile, but produces a ~1.6x smaller binary.
-[profile.release-size]
-inherits = "release"
-lto = true
-codegen-units = 1
-opt-level = "s"
-
 # The fuzzer in the e2e-tests crate will time out without optimizations enabled.
 # It is ignored by default, to run it one must use `cargo test --test fuzzer`.
 # Only the fuzzer tests actually time out without optimizations, and yes


### PR DESCRIPTION
Per our session today, here are the profile changes I suggest. The commits have more detailed reasoning for each.

As an example in regard to stripping, Arch Linux builds all packages without explicitly stripping and various compiler default options set to *not* strip binaries. Then at the last stage of the build, it runs `split` on the binaries that would be installed, but stashes the debug symbols that get split out. If there are any, it will package them in a separate package (`teamtype-debug`). This goes in a separate repository and most people will never download or use it.

But there is magic. It is possible to enable the debug repositories and enable some hooks so that if user runs `gdb teamtype` or triggers various other debug scenarios, the package that actually has the debug symbols will be downloaded and installed first, then the debugger will combine the stripped symbols with the original binary so you can actually run a debugger on the final stripped release artifact and still get meaningful debug information.

What will happen in the current scenario is that the `teamtype` package will be stripped (expected) and the `teamtype-debug` package will be empty (because the symbols were removed before the packaging even saw the artifact) and people will not be able to debug it. Here is what I see with Arch's current package:

Debian, Gentoo, and many other distros have similar systems. Not all of them package symbols or wire things up so they are easy to get, but even the ones that just discard the debug information at least typically strip binaries so the project build system doesn't need to worry about it.

**Self-review checklist**

- [x] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
