### PR TITLE
Baby sit the version of stuff running in CI

### DIFF
--- a/.github/workflows/deploy-nvim-plugin.yml
+++ b/.github/workflows/deploy-nvim-plugin.yml
@@ -18,7 +18,7 @@ jobs:
     name: Mirror to teamtype/teamtype-nvim
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: s0/git-publish-subdir-action@develop
         env:
           REPO: git@github.com:teamtype/teamtype-nvim

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -32,7 +32,7 @@ jobs:
         nvim-version: [v0.9.5, v0.10.4, v0.11.2]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Rust toolchain
         run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
@@ -62,7 +62,7 @@ jobs:
     name: Check Rust formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: cargo fmt --check
 
   clippy:
@@ -74,7 +74,7 @@ jobs:
     env:
       RUSTFLAGS: --deny warnings
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Rust toolchain
         run: rustup toolchain install stable --profile minimal --component=clippy
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -29,7 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        nvim-version: [v0.9.5, v0.10.4, v0.11.2]
+        nvim-version: [v0.12.2]
+        include:
+          - os: ubuntu-latest
+            nvim-version: v0.9.5
+          - os: ubuntu-latest
+            nvim-version: v0.10.4
+          - os: ubuntu-latest
+            nvim-version: v0.11.7
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -7,16 +7,8 @@ name: General tests
 on:
   push:
     branches:
-      - 'main'
-    paths:
-      - 'crates/**'
-      - 'nvim-plugin/**'
-      - '.github/workflows/general.yml'
+      - main
   pull_request:
-    paths:
-      - 'crates/**'
-      - 'nvim-plugin/**'
-      - '.github/workflows/general.yml'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -30,7 +30,7 @@ jobs:
       pages: write  # To push to a GitHub Pages site
       id-token: write # To update the deployment status
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install latest mdbook
@@ -45,11 +45,11 @@ jobs:
           cd book
           mdbook build
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'book/book'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/nvim-plugin.yml
+++ b/.github/workflows/nvim-plugin.yml
@@ -21,8 +21,8 @@ jobs:
     name: Check Lua formatting and linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: JohnnyMorganz/stylua-action@v4
+      - uses: actions/checkout@v6
+      - uses: JohnnyMorganz/stylua-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.20.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: taiki-e/create-gh-release-action@v1
         with:
           changelog: CHANGELOG.md
@@ -37,7 +37,7 @@ jobs:
             os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: teamtype
@@ -50,7 +50,7 @@ jobs:
     name: Mirror Neovim plugin to teamtype/teamtype-nvim
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: s0/git-publish-subdir-action@develop
         env:
           REPO: git@github.com:teamtype/teamtype-nvim

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -14,6 +14,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v5
+        uses: fsfe/reuse-action@v6


### PR DESCRIPTION
This isn't the complete overhaul the CI jobs needs, but at least it should get rid of the constant warnings about EOL actions we're running that have old Node versions and make GHA very unhappy.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [-] I have manually tested and self-reviewed my changes.
- [-] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
