### PR TITLE
Retry instead of hang indefinitely on failure to reach Magic Wormhole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # 0.9.2 (unreleased)
 
+Continue trying to contact Magic Wormhole on a 5 minute cycle in the event join codes fail to register.
+
 Add status widget to the Neovim plugin with basic information to be used in statuslines.
 
 Fix issue blocking directories with deep nesting (or very long winded names) from being shared.

--- a/crates/teamtype/src/wormhole.rs
+++ b/crates/teamtype/src/wormhole.rs
@@ -8,7 +8,9 @@ use std::{borrow::Cow, str::FromStr, time::Duration};
 use anyhow::Result;
 use magic_wormhole::{AppConfig, AppID, Code, MailboxConnection, Wormhole, transfer};
 use tokio::time::sleep;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
+
+const NETWORK_RETRY: Duration = Duration::from_secs(300);
 
 pub async fn put_secret_address_into_wormhole(address: &str, magic_wormhole_relay: Option<String>) {
     let payload: Vec<u8> = address.into();
@@ -17,10 +19,12 @@ pub async fn put_secret_address_into_wormhole(address: &str, magic_wormhole_rela
     tokio::spawn(async move {
         loop {
             let Ok(mailbox_connection) = MailboxConnection::create(config.clone(), 2).await else {
-                error!(
-                    "Failed to share join code via Magic Wormhole. Restart Teamtype to try again."
+                warn!(
+                    "Failed to register a new join code via Magic Wormhole. Automatic retry in {:?}. Peers who joined before can still re-connect without a code.",
+                    NETWORK_RETRY
                 );
-                return;
+                sleep(NETWORK_RETRY).await;
+                continue;
             };
             let code = mailbox_connection.code().clone();
 


### PR DESCRIPTION
I was hanging out on a bad internet connection today and trying to work on user messaging issues. I ran across this `error!` which procedes to hang indefinitely and make it impossible to connect or add peers. I don't understand why this should be a show stopper. If the daemon needs restarting we should be actually raising an `Err()` here. I was going to fix the function signature to bubble up an error, but that didn't seem right either since it might disconnect peers that *are* connected even if the network segment with the MW relay is actually down.

In the end I don't see any realy reason not to retry here, at least not at a conservative rate.

**Self-review checklist**

- [x] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
