### PR TITLE
Add Nix flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # 0.9.2 (unreleased)
 
+Add a Nix Flake to the project so the repository can be run directly, used as a dependency, or just to supply a developer environment.
+
 Continue trying to contact Magic Wormhole on a 5 minute cycle in the event join codes fail to register.
 
 Add status widget to the Neovim plugin with basic information to be used in statuslines.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,8 @@ unused_qualifications = "warn"
 
 [workspace.metadata.typos.default]
 locale = "en-us"
-extend-words = {
-    ot = "ot"
-}
+# Note: the TOML parser used in the Nix flake can't handle inline tables on multiple lines.
+extend-words = { ot = "ot" }
 extend-ignore-identifiers-re = [
     "2nd",
 ]

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,7 @@ cargo := require('cargo')
 cargo-deny := require('cargo-deny')
 just := just_executable()
 luacheck := require('luacheck')
+nix := require('nix')
 nvim := require('nvim')
 reuse := require('reuse')
 stylua := require('stylua')
@@ -68,12 +69,16 @@ build-test *ARGS:
 
 [group('format')]
 [parallel]
-format: format-lua format-rust
+format: format-lua format-nix format-rust
 
 [group('format')]
 [working-directory("nvim-plugin")]
 format-lua:
     {{ stylua }} --respect-ignores .
+
+[group('format')]
+format-nix:
+    {{ nix }} fmt flake.nix
 
 [group('format')]
 format-rust:

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -2,6 +2,6 @@ version = 1
 
 # Computer-generated files.
 [[annotations]]
-path = ["**/Cargo.lock", "**/package-lock.json", "**/initial_automerge_doc.bin"]
+path = ["**/Cargo.lock", "**/package-lock.json", "**/initial_automerge_doc.bin", "flake.lock"]
 SPDX-FileCopyrightText = "NONE"
 SPDX-License-Identifier = "CC0-1.0"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1780715792,
+        "narHash": "sha256-4+8gPeiPeud89mjo865RwpqmKwa1MThRsq2SvRxo7mg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "27b7e78c6935293ee868469cc4172e9b8b17823b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: 2026 blinry <mail@blinry.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-
 {
   description = "Enables real-time co-editing of local text files.";
 
@@ -87,6 +86,7 @@
           packages.teamtype = rustPackage [ ];
           packages.default = self'.packages.teamtype;
           devShells.default = mkDevShell;
+          formatter = pkgs.nixfmt;
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+# SPDX-FileCopyrightText: 2026 blinry <mail@blinry.org>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+{
+  description = "Enables real-time co-editing of local text files.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem =
+        {
+          config,
+          self',
+          pkgs,
+          lib,
+          system,
+          ...
+        }:
+        let
+          runtimeDeps = with pkgs; [ ];
+          buildDeps = with pkgs; [ ];
+          devDeps = with pkgs; [
+            cargo-deny
+            just
+            luaPackages.luacheck
+            reuse
+            rustup
+            stylua
+            typos
+          ];
+
+          workspaceToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+          cargoToml = builtins.fromTOML (builtins.readFile ./crates/teamtype/Cargo.toml);
+
+          resolve =
+            key:
+            if builtins.isAttrs cargoToml.package.${key} && cargoToml.package.${key} ? workspace then
+              workspaceToml.workspace.package.${key}
+            else
+              cargoToml.package.${key};
+
+          msrv = resolve "rust-version";
+
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = pkgs.rust-bin.stable.latest.minimal;
+            rustc = pkgs.rust-bin.stable.latest.minimal;
+          };
+
+          rustPackage =
+            features:
+            rustPlatform.buildRustPackage {
+              name = resolve "name";
+              version = resolve "version";
+              src = ./.;
+              cargoLock.lockFile = ./Cargo.lock;
+              buildFeatures = features;
+              buildInputs = runtimeDeps;
+              nativeBuildInputs = buildDeps;
+              doCheck = false;
+            };
+
+          mkDevShell = pkgs.mkShell {
+            buildInputs = runtimeDeps;
+            nativeBuildInputs = buildDeps ++ devDeps;
+          };
+        in
+        {
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ (import inputs.rust-overlay) ];
+          };
+
+          packages.teamtype = rustPackage [ ];
+          packages.default = self'.packages.teamtype;
+          devShells.default = mkDevShell;
+        };
+    };
+}


### PR DESCRIPTION
All the usual goodies like `nix run`, `nix develop`, `nix shell`, and such should work.

This is the first time I've used this particular combination of flake overlays for working with Rust. Most of my projects use autotools and my usual go-to for flakes is the *naersk* overlay. See for example the [flake for `decasify`](https://github.com/alerque/decasify/blob/master/flake.nix). I'm generally happy with that, but I ran across [this example here](https://log.woodweb.ca/articles/rust-flake/) that included the dev shells split for different Rust toolchain versions and I thought that might be useful so I decided to give it a spin. This flake is largely derived from there with some modifications of my own and a dev dependency list from a comment of @blinry that had a dependency flake.

A caveat on the LLM issue here, this actually does have a very small GenAI contribution. I beat my head against a nix language parse error for a long time and regular web searches for the problem were not getting me anywhere. The Nix compile errors were completely inscrutable to me and I decided to see if an LLM could find the cause. Somewhat to my surprise OpenCode w/ Big Pickle cut straight to the root problem. The issue wasn't my Nix syntax at all or and all the workarounds I'd been trying were way off. The issue is the TOML parser built into Nix (`builtins.fromTOML`) has some limitations and couldn't handle the otherwise valid inline table formatted over multiple lines. GAH! The resulting fix is technically LLM generated code but also the fix so trivial that once I knew what the problem is impossible to unsee and the only way to fix it without exactly copying the code would be to break the table out into a new section which is even more unnecessary for a single-entry table.

**Self-review checklist**

- [x] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [-] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
