### PR TITLE
Run Rust lints and checks on --all-targets by default

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -43,7 +43,7 @@ check *ARGS: (check-cargo ARGS) check-typos
 
 [group('check')]
 check-cargo *ARGS:
-    {{ cargo }} check {{ ARGS }}
+    {{ cargo }} check --all-targets --all-features {{ ARGS }}
 
 [group('check')]
 check-typos:
@@ -111,7 +111,7 @@ lint-manifests:
 
 [group('lint')]
 lint-rust:
-    {{ cargo }} clippy
+    {{ cargo }} clippy --all-targets --all-features
 
 [group('test')]
 test *ARGS: (test-cargo ARGS)
@@ -135,8 +135,8 @@ perfect: check lint test fuzz
 #     alias nvim='just --justfile ~/path/to/teamtype/Justfile nvim'
 #
 # Run Neovim with the plug-in for testing (can be used from outside the project).
-[script]
 [no-cd]
+[script]
 nvim *ARGS: build-test
     {{ nvim }} --clean \
         --cmd {{ quote("let &runtimepath=\"" + justfile_directory() + "/nvim-plugin,\" . &runtimepath") }} \
@@ -150,7 +150,7 @@ nvim *ARGS: build-test
 #     alias teamtype='just --justfile ~/path/to/teamtype/Justfile teamtype'
 #
 # Build and run Teamtype for testing (can be used from outside the project).
-[script]
 [no-cd]
+[script]
 teamtype *ARGS: build-test
     $TEAMTYPE_BINARY {{ maybe-pass(ARGS) }}


### PR DESCRIPTION
Just some local developer job defaults here...

This helps a bit with the Windows branch as we're starting to collect some platform specific guards so not all code paths are checked by default. This doesn't make sense for the build or test jobs since that would require a cross-platform build chain was available, but the `cargo check` and `cargo clippy` tools can be used pretty simply to analyze all targets at once.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
