### PR TITLE
Use new Just (1.52) feature so list job doesn't require tooling

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,8 @@ export TEAMTYPE_BINARY := justfile_directory() + "/target/debug/teamtype"
 set script-interpreter := ['bash', '-eu']
 set shell := ['bash', '-eu', '-c']
 
+set default-list
+set default-script
 set positional-arguments
 set unstable
 
@@ -50,11 +52,6 @@ check-cargo *ARGS:
 [group('check')]
 check-typos:
     {{ typos }}
-
-[default]
-[private]
-@list:
-    {{ just }} --list --unsorted
 
 [group('build')]
 build *ARGS:
@@ -150,7 +147,6 @@ perfect: check lint test fuzz
 #
 # Run Neovim with the plug-in for testing (can be used from outside the project).
 [no-cd]
-[script]
 nvim *ARGS: build-test
     {{ nvim }} --clean \
         --cmd {{ quote("let &runtimepath=\"" + justfile_directory() + "/nvim-plugin,\" . &runtimepath") }} \
@@ -165,6 +161,5 @@ nvim *ARGS: build-test
 #
 # Build and run Teamtype for testing (can be used from outside the project).
 [no-cd]
-[script]
 teamtype *ARGS: build-test
     $TEAMTYPE_BINARY {{ maybe-pass(ARGS) }}

--- a/crates/teamtype/build.rs
+++ b/crates/teamtype/build.rs
@@ -126,7 +126,7 @@ fn formulate_version() -> Result<&'static str> {
         if manifest_version != captures["tag"] {
             println!(
                 "cargo::warning=The most recent annotated tag '{}' does not match the manifest version '{}'.",
-                &captures["tag"], &manifest_version
+                &captures["tag"], manifest_version
             );
         }
         // The `git describe` used by vergen will not output the counter on a tag anyway, but our

--- a/nvim-plugin/doc/teamtype.txt
+++ b/nvim-plugin/doc/teamtype.txt
@@ -15,7 +15,7 @@ CONFIGURATION                                           *teamtype-configuration*
 
 This plugin allows you to configure multiple collaboration servers. Each is
 identified with a name and markers or a function used to identify what
-directory(s) the config should be active for. This enables separeate settings
+directory(s) the config should be active for. This enables separate settings
 per-project or per group of projects.
 
 A default configuration for connecting to Teamtype daemons is provided. To


### PR DESCRIPTION
When we were merging #552 we discussed the inconvenience of having to check for all the devevloper tooling just to run the `list` job that showed what you *could* do. One thing I missed at that point was that the only problem with `list` was that we had it setup as a custom job target to fiddle with the order and allow it to work when invoking `just` with no arguments. It turns out we could always have run `just --list` directly because that doesn't invoke any jobs and hence doesn't evaluate expressions at all, hence not tripping the `require()` functions.

With the recent Just 1.52 release, there is now a way to configure the list action as the default and there have been other cleanups such that I consider our list target to be unnecessary cruft.

I suggest letting this PR sit until @blinry and @zormit's platform of choice has Just 1.52 packaged and installed by default, then we can put this through. There is no urgency, but it's just a tiny bit tidier.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
