### PR TITLE
Include relative commit counter in dev versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e-tests"
-version = "0.9.2-dev"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4553,7 +4553,7 @@ dependencies = [
 
 [[package]]
 name = "teamtype"
-version = "0.9.2-dev"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1095,37 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "derive_more"
@@ -1602,6 +1668,19 @@ dependencies = [
 
 [[package]]
 name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "git2"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
@@ -2045,6 +2124,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3000,6 +3085,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4471,7 +4565,7 @@ dependencies = [
  "derive_more 2.1.1",
  "dissimilar",
  "futures 0.3.32",
- "git2",
+ "git2 0.21.0",
  "ignore",
  "iroh",
  "magic-wormhole",
@@ -4482,6 +4576,7 @@ dependencies = [
  "postcard",
  "pretty_assertions",
  "rand 0.8.6",
+ "regex",
  "ropey",
  "rust-ini",
  "serde",
@@ -4494,6 +4589,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "url",
+ "vergen-git2",
 ]
 
 [[package]]
@@ -4566,7 +4662,9 @@ checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
  "js-sys",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -5055,6 +5153,44 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "git2 0.20.4",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 members = ["crates/teamtype", "crates/e2e-tests"]
 
 [workspace.package]
-version = "0.9.2-dev"
+version = "0.9.1"
 authors = [
     "Moritz Neeb <nt4u@kpvn.de>",
     "blinry <mail@blinry.org>",

--- a/crates/teamtype/Cargo.toml
+++ b/crates/teamtype/Cargo.toml
@@ -45,10 +45,15 @@ anyhow.workspace = true
 automerge = "0.8"
 clap_complete = "4"
 clap_mangen = "0.3"
+regex = "1"
 
 [build-dependencies.clap]
 version = "4"
 features = ["derive", "env"]
+
+[build-dependencies.vergen-git2]
+version = "9"
+features = ["emit_and_set"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/teamtype/build.rs
+++ b/crates/teamtype/build.rs
@@ -6,7 +6,6 @@
 use std::env::{var, var_os};
 use std::fs::{create_dir_all, read, remove_dir_all, write};
 use std::path::Path;
-use std::process::Command;
 
 use anyhow::Result;
 use automerge::{AutoCommit, ObjType, transaction::Transactable};
@@ -14,17 +13,21 @@ use clap::{CommandFactory as _, ValueEnum as _};
 use clap_complete::Shell;
 use clap_complete::generate_to as generate_completions_to;
 use clap_mangen::generate_to as generate_manpages_to;
+use regex::Regex;
+use vergen_git2::{Emitter, Git2Builder};
 
 include!("src/cli.rs");
 
 fn main() -> Result<()> {
     instantiate_initial_automerge_doc()?;
-    pass_on_git_version_details();
+    let version = derive_version_details()?;
+    // Pass version info for use in CLI's --version flag.
+    println!("cargo::rustc-env=TEAMTYPE_VERSION={version}");
     // Skip generating extra artifacts if being run via `cargo install --git ...`.
     println!("cargo::rerun-if-env-changed=CARGO_WORKSPACE_DIR");
     if var_os("CARGO_WORKSPACE_DIR").is_some() {
-        output_completions()?;
-        output_manpages()?;
+        output_completions(version)?;
+        output_manpages(version)?;
     }
     Ok(())
 }
@@ -59,7 +62,7 @@ fn instantiate_initial_automerge_doc() -> Result<()> {
     Ok(())
 }
 
-fn output_completions() -> Result<()> {
+fn output_completions(version: &'static str) -> Result<()> {
     const BIN_NAME: &str = env!("CARGO_PKG_NAME");
     let workspace_root = PathBuf::from(var("CARGO_WORKSPACE_DIR")?);
     let target_dir = &workspace_root.join("target");
@@ -67,52 +70,79 @@ fn output_completions() -> Result<()> {
     _ = remove_dir_all(compl_dir);
     create_dir_all(compl_dir)?;
     for &shell in Shell::value_variants() {
-        generate_completions_to(shell, &mut Cli::command(), BIN_NAME, compl_dir)?;
+        generate_completions_to(
+            shell,
+            &mut Cli::command().version(version),
+            BIN_NAME,
+            compl_dir,
+        )?;
     }
     Ok(())
 }
 
-fn output_manpages() -> Result<()> {
+fn output_manpages(version: &'static str) -> Result<()> {
     let workspace_root = PathBuf::from(var("CARGO_WORKSPACE_DIR")?);
     let target_dir = &workspace_root.join("target");
     let man_dir = &target_dir.join("manpages");
     _ = remove_dir_all(man_dir);
     create_dir_all(man_dir)?;
-    Ok(generate_manpages_to(Cli::command(), man_dir)?)
+    Ok(generate_manpages_to(
+        Cli::command().version(version),
+        man_dir,
+    )?)
 }
 
-fn pass_on_git_version_details() {
-    const VERSION: &str = env!("CARGO_PKG_VERSION");
-    // Only add more information on pre-release versions.
-    if VERSION.contains('-') {
-        // Git hash
-        let git_hash = Command::new("git")
-            .args(["rev-parse", "--short=9", "HEAD"])
-            .output()
-            .ok()
-            .filter(|output| output.status.success())
-            .and_then(|output| String::from_utf8(output.stdout).ok())
-            .map_or_else(|| "unknown".to_string(), |s| s.trim().to_string());
-
-        // Commit date
-        let commit_date = Command::new("git")
-            .args(["log", "-1", "--format=%cs"])
-            .output()
-            .ok()
-            .filter(|output| output.status.success())
-            .and_then(|output| String::from_utf8(output.stdout).ok())
-            .map_or_else(|| "unknown".to_string(), |s| s.trim().to_string());
-
-        // Check if working directory is dirty
-        let is_dirty = Command::new("git")
-            .args(["status", "--porcelain"])
-            .output()
-            .ok()
-            .filter(|output| output.status.success())
-            .is_some_and(|output| !output.stdout.is_empty());
-
-        println!("cargo::rustc-env=GIT_HASH={git_hash}");
-        println!("cargo::rustc-env=GIT_COMMIT_DATE={commit_date}");
-        println!("cargo::rustc-env=GIT_DIRTY={is_dirty}");
+fn derive_version_details() -> Result<&'static str> {
+    if var("VERGEN_GIT_SHA").is_err() {
+        (|| -> Result<()> {
+            let git2 = Git2Builder::all_git()?;
+            Emitter::default().add_instructions(&git2)?.emit_and_set()?;
+            Ok(())
+        })()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Could not determine git version info: {e}\n\
+                 Either build from a git checkout, or set VERGEN_GIT_SHA, \
+                 VERGEN_GIT_COMMIT_DATE, VERGEN_GIT_DIRTY, and VERGEN_GIT_DESCRIBE."
+            )
+        })?;
     }
+    let version = formulate_version()?;
+    Ok(version)
+}
+
+// Take special environment variables passed by Cargo during the build and bundle them up into our
+// desired version string format in a way that Clap will digest at build time in a derive macro.
+fn formulate_version() -> Result<&'static str> {
+    let manifest_version = env!("CARGO_PKG_VERSION").to_string();
+    let git_sha = var("VERGEN_GIT_SHA")?;
+    let commit_date = var("VERGEN_GIT_COMMIT_DATE")?;
+    let is_dirty = var("VERGEN_GIT_DIRTY")?;
+    // The `git describe` handler only picks up *annotated* tags, which through 0.9.1 were not made.
+    let git_describe = var("VERGEN_GIT_DESCRIBE")?;
+    let describe_expression =
+        Regex::new(r"^v(?<tag>\d+\.\d+\.\d+)-(?<counter>\d+)-g(?<sha>[0-9a-f]+)$")?;
+    let semver = if let Some(captures) = describe_expression.captures(&git_describe) {
+        if manifest_version != captures["tag"] {
+            println!(
+                "cargo::warning=The most recent annotated tag '{}' does not match the manifest version '{}'.",
+                &captures["tag"], &manifest_version
+            );
+        }
+        // The `git describe` used by vergen will not output the counter on a tag anyway, but our
+        // reconstruction of the same data in the Nix flake might.
+        if &captures["counter"] == "0" {
+            captures["tag"].to_string()
+        } else {
+            format!("{}+r{}", &captures["tag"], &captures["counter"])
+        }
+    } else {
+        manifest_version
+    };
+    let dirty_suffix = matches!(is_dirty.as_ref(), "true")
+        .then_some("-dirty")
+        .unwrap_or("");
+    let git_sha_prefix = git_sha.get(..9).unwrap_or(&git_sha);
+    let version = format!("{semver} ({git_sha_prefix}{dirty_suffix} {commit_date})");
+    Ok(Box::leak(version.into_boxed_str()))
 }

--- a/crates/teamtype/src/cli.rs
+++ b/crates/teamtype/src/cli.rs
@@ -8,25 +8,9 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
 
-fn get_version() -> &'static str {
-    let version = env!("CARGO_PKG_VERSION");
-    let git_hash = option_env!("GIT_HASH");
-    let commit_date = option_env!("GIT_COMMIT_DATE");
-    let is_dirty = option_env!("GIT_DIRTY").unwrap_or("false") == "true";
-
-    let version = match (git_hash, commit_date) {
-        (Some(hash), Some(date)) if hash != "unknown" && date != "unknown" => {
-            let dirty_suffix = if is_dirty { "-modified" } else { "" };
-            format!("{version} ({hash}{dirty_suffix} {date})")
-        }
-        _ => version.to_string(),
-    };
-    Box::leak(version.into_boxed_str())
-}
-
 // TODO: Define these constants in the teamtype crate, and use them here.
 #[derive(Parser)]
-#[command(version=get_version(), about, long_about = None)]
+#[command(about, long_about = None)]
 #[command(propagate_version = true)]
 pub struct Cli {
     #[command(subcommand)]

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -51,7 +51,8 @@ async fn main() -> Result<()> {
         exit(1);
     }));
 
-    let arg_matches = Cli::command().get_matches();
+    let version = option_env!("TEAMTYPE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+    let arg_matches = Cli::command().version(version).get_matches();
     let cli = match Cli::from_arg_matches(&arg_matches) {
         Ok(cli) => cli,
         Err(e) => e.exit(),


### PR DESCRIPTION
As previously discussed, changing the Cargo manifest with a new version before release time has several pitfalls, not the least of which is you may not know for sure what the next target version is.

This should automate that with a commit counter relative to the previous annotated commit.

As a side note none of the releases through 0.9.1 were made with annotated commits, so this won't work well until either after the next release or if we force push replacement tags, something like this:

```zsh
#!/usr/bin/env zsh

for tag in $(git tag); do
	if [[ $(git cat-file -t "$tag" 2>/dev/null) == "tag" ]]; then
		echo "Skipping $tag"
		continue
	fi
	commit=$(git rev-parse "$tag^{commit}")
	date=$(git log -1 --format=%aI "$commit")
	name=$(git log -1 --format=%an "$commit")
	email=$(git log -1 --format=%ae "$commit")
	git tag -d "$tag"
	GIT_COMMITTER_DATE="$date" GIT_COMMITTER_NAME="$name" GIT_COMMITTER_EMAIL="$email" git tag -a "$tag" "$commit" -m "Release $tag"
	echo "Converted $tag"
done

git push --tags --force
```

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
