### PR TITLE
docs: add doc comment to config module

### DIFF
--- a/crates/teamtype/src/lib.rs
+++ b/crates/teamtype/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![doc = include_str!("../../../README.md")]
 
+/// Configuration management for the crate.
 pub mod config;
 pub mod daemon;
 pub mod document;


### PR DESCRIPTION
### 问题背景
The public module `config` lacked a documentation comment, which is important for code clarity and maintainability in Rust projects. Adding a doc comment improves readability and helps other contributors understand the module's purpose.

### 修改内容
- Added a doc comment `/// Configuration management for the crate.` to the `config` module declaration in `crates/teamtype/src/lib.rs`.
- This change follows Rust best practices for documentation, enhancing code quality without altering functionality.

### 验证方式
- Verified that the change does not break existing tests by running `cargo test`.
- Confirmed that the documentation renders correctly with `cargo doc`.

### 其他信息
- No breaking changes.
- No additional documentation updates required.