### PR TITLE
feat(vscode-plugin): #416 follow cursor command

### DIFF
--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -17,6 +17,10 @@
             {
                 "command": "teamtype.showCursors",
                 "title": "Teamtype: List other cursor positions"
+            },
+            {
+                "command": "teamtype.followCursor",
+                "title": "Teamtype: Follow a user's cursor"
             }
         ],
         "configuration": {

--- a/vscode-plugin/src/cursor.ts
+++ b/vscode-plugin/src/cursor.ts
@@ -17,11 +17,6 @@ const selectionDecorationType = vscode.window.createTextEditorDecorationType({
     },
 })
 
-interface RemoteCursor {
-    name: string
-    uri: vscode.Uri
-    selection: vscode.DecorationOptions
-}
 
 let cursors: Map<string, RemoteCursor[]> = new Map()
 

--- a/vscode-plugin/src/cursor.ts
+++ b/vscode-plugin/src/cursor.ts
@@ -3,78 +3,133 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import * as vscode from "vscode"
+import * as vscode from "vscode";
 
 const selectionDecorationType = vscode.window.createTextEditorDecorationType({
-    backgroundColor: "#1a4978",
-    borderRadius: "0.1rem",
-    rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
-    before: {
-        color: "#548abf",
-        contentText: "ᛙ",
-        margin: "0px 0px 0px -0.35ch",
-        textDecoration: "font-weight: bold; position: absolute; top: 0; font-size: 200%; z-index: 0;",
-    },
-})
+  backgroundColor: "#1a4978",
+  borderRadius: "0.1rem",
+  rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
+  before: {
+    color: "#548abf",
+    contentText: "ᛙ",
+    margin: "0px 0px 0px -0.35ch",
+    textDecoration: "font-weight: bold; position: absolute; top: 0; font-size: 200%; z-index: 0;",
+  },
+});
 
-
-let cursors: Map<string, RemoteCursor[]> = new Map()
+let cursors: Map<string, RemoteCursor[]> = new Map();
+let useridToFollow: string | null = null;
 
 export function setCursor(userid: string, name: string, uri: vscode.Uri, selections: vscode.DecorationOptions[]) {
-    let usersCursors = cursors.get(userid)
-    if (usersCursors) {
-        // Remove all decorations by this user.
-        for (let cursor of usersCursors) {
-            // TODO: Refactor this into drawCursors below?
-            const editors = vscode.window.visibleTextEditors.filter(
-                (editor) => editor.document.uri.toString() === cursor.uri.toString(),
-            )
-            for (const editor of editors) {
-                editor.setDecorations(selectionDecorationType, [])
-            }
-        }
+  let usersCursors = cursors.get(userid);
+  if (usersCursors) {
+    // Remove all decorations by this user.
+    for (let cursor of usersCursors) {
+      // TODO: Refactor this into drawCursors below?
+      const editors = vscode.window.visibleTextEditors.filter(
+        (editor) => editor.document.uri.toString() === cursor.uri.toString(),
+      );
+      for (const editor of editors) {
+        editor.setDecorations(selectionDecorationType, []);
+      }
     }
+  }
 
-    let newCursors = selections.map((s) => {
-        return {name, selection: s, uri}
-    })
-    cursors.set(userid, newCursors)
+  let newCursors = selections.map((s) => {
+    return { name, selection: s, uri };
+  });
+  cursors.set(userid, newCursors);
 
-    const editors = vscode.window.visibleTextEditors.filter((editor) => editor.document.uri.toString() === uri.toString())
-    for (let editor of editors) {
-        drawCursors(editor)
-    }
+  const editors = vscode.window.visibleTextEditors.filter(
+    (editor) => editor.document.uri.toString() === uri.toString(),
+  );
+  for (let editor of editors) {
+    drawCursors(editor);
+  }
 }
 
 export function getCursorInfo(): string {
-    if (cursors.size == 0) {
-        return "(No cursors.)"
-    } else {
-        let message: string[] = []
-        cursors.forEach((usersCursors, _userid) => {
-            for (let cursor of usersCursors) {
-                let line1 = cursor.selection.range.start.line + 1
-                let line2 = cursor.selection.range.end.line + 1
-                if (line1 > line2) {
-                    ;[line1, line2] = [line2, line1]
-                }
-                let position = line1 == line2 ? `${line1}` : `${line1}-${line2}`
+  if (cursors.size == 0) {
+    return "(No cursors.)";
+  } else {
+    let message: string[] = [];
+    cursors.forEach((usersCursors, _userid) => {
+      for (let cursor of usersCursors) {
+        let line1 = cursor.selection.range.start.line + 1;
+        let line2 = cursor.selection.range.end.line + 1;
+        if (line1 > line2) {
+          ;[line1, line2] = [line2, line1];
+        }
+        let position = line1 == line2 ? `${line1}` : `${line1}-${line2}`;
 
-                // TODO: Trim URI to the relevant parts inside the project.
-                message.push(`${cursor.name} @ ${cursor.uri}:${position}`)
-            }
-        })
-        return message.join("\n")
-    }
+        // TODO: Trim URI to the relevant parts inside the project.
+        message.push(`${cursor.name} @ ${cursor.uri}:${position}`);
+      }
+    });
+    return message.join("\n");
+  }
 }
 
 export function drawCursors(editor: vscode.TextEditor | undefined) {
-    if (editor) {
-        let uri = editor.document.uri;
-        let allSelections = Array.from(cursors.values())
-            .flat()
-            .filter(cursor => cursor.uri.toString() === uri.toString())
-            .map(cursor => cursor.selection);
-        editor.setDecorations(selectionDecorationType, allSelections)
+  if (editor) {
+    let uri = editor.document.uri;
+    let allSelections = Array.from(cursors.values())
+      .flat()
+      .filter((cursor) => cursor.uri.toString() === uri.toString())
+      .map((cursor) => cursor.selection);
+    editor.setDecorations(selectionDecorationType, allSelections);
+  }
+}
+
+/// this function is used to follow other users' cursors in the editor. It will be called when the user moves their cursor, and it will send the new cursor position to the daemon.
+export async function syncFollowCursor() {
+  try {
+    if (!useridToFollow) {
+      return;
     }
+    const usersCursors = cursors.get(useridToFollow);
+    if (!usersCursors || usersCursors.length === 0) {
+      return;
+    }
+    const usersCursor = usersCursors[0];
+    const editors = vscode.window.visibleTextEditors.filter((editor) => editor.document.uri.toString() === usersCursor.uri.toString());
+    if (editors.length === 0) {
+      // create editor for the user cursor if it doesn't exist
+      const document = await vscode.workspace.openTextDocument(usersCursor.uri);
+      editors.push(await vscode.window.showTextDocument(document, { preview: false }));
+    }
+    const editor = editors[0];
+    const selection = usersCursor.selection;
+    editor.revealRange(selection.range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+    editor.selection = new vscode.Selection(selection.range.start, selection.range.end);
+  } catch { }
+}
+export async function followCursor() {
+
+  const items: vscode.QuickPickItem[] = [
+    { label: "$(circle-slash) Stop following", description: "__stop__", alwaysShow: true },
+  ];
+
+  cursors.forEach((remoteCursors, uid) => {
+    if (remoteCursors.length > 0) {
+      const label = useridToFollow === uid ? `$(link) ${remoteCursors[0].name}` : remoteCursors[0].name;
+      items.push({ label, description: uid });
+    }
+  });
+
+  const picked = await vscode.window.showQuickPick(items, {
+    placeHolder: "Follow which user?",
+  });
+
+  if (!picked) { return; }
+
+  if (picked.description === "__stop__") {
+    useridToFollow = null;
+    return;
+  }
+
+  useridToFollow = picked.description || null;
+  if (useridToFollow) {
+    await syncFollowCursor();
+  }
 }

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -10,7 +10,7 @@ import * as path from "path"
 import * as fs from "fs"
 import { Mutex } from "async-mutex";
 
-import {setCursor, getCursorInfo, drawCursors} from "./cursor"
+import {setCursor, getCursorInfo, drawCursors, followCursor, syncFollowCursor} from "./cursor"
 
 function findMarkerDirectory(dir: string, marker: string) {
     if (fs.existsSync(path.join(dir, marker))) {
@@ -261,6 +261,7 @@ async function processCursorFromDaemon(cursor: CursorFromDaemon) {
                 })
         }
         setCursor(cursor.userid, cursor.name || "anonymous", vscode.Uri.parse(uri), selections)
+        await syncFollowCursor()
     } catch {
         // If we couldn't convert teamtypeRangeToVSCodeRange, it's probably because
         // we received the cursor message before integrating the edits, typing at the end of a line.
@@ -477,6 +478,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.onDidChangeTextEditorSelection(processSelection),
         vscode.window.onDidChangeActiveTextEditor(drawCursors),
         vscode.commands.registerCommand("teamtype.showCursors", showCursorNotification),
+        vscode.commands.registerCommand("teamtype.followCursor", followCursor)
     )
 
     openCurrentTextDocuments()
@@ -507,3 +509,4 @@ function getLines(document: vscode.TextDocument): string[] {
     }
     return lines
 }
+

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -8,7 +8,7 @@ import * as cp from "child_process"
 import * as rpc from "vscode-jsonrpc/node"
 import * as path from "path"
 import * as fs from "fs"
-var Mutex = require("async-mutex").Mutex
+import { Mutex } from "async-mutex";
 
 import {setCursor, getCursorInfo, drawCursors} from "./cursor"
 
@@ -27,52 +27,9 @@ function findMarkerDirectory(dir: string, marker: string) {
     return findMarkerDirectory(parentDir, marker)
 }
 
-interface Position {
-    line: number
-    character: number
-}
-
-interface Range {
-    start: Position
-    end: Position
-}
-
-interface Delta {
-    range: Range
-    replacement: string
-}
-
-interface Edit {
-    uri: string
-    revision: number
-    delta: Delta[]
-}
-
-interface Cursor {
-    uri: string
-    ranges: Range[]
-}
-
-interface CursorFromDaemon {
-    userid: string
-    name?: string
-    uri: string
-    ranges: Range[]
-}
-
 class Revision {
     daemon = 0
     editor = 0
-}
-
-interface Configuration {
-    cmd: string[]
-    rootMarkers: string[]
-}
-
-interface DocumentOTState {
-    revision: Revision
-    content: string[]
 }
 
 class Client {

--- a/vscode-plugin/src/types/teamtype.d.ts
+++ b/vscode-plugin/src/types/teamtype.d.ts
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
+// SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 interface Position {
     line: number
     character: number

--- a/vscode-plugin/src/types/teamtype.d.ts
+++ b/vscode-plugin/src/types/teamtype.d.ts
@@ -1,0 +1,53 @@
+interface Position {
+    line: number
+    character: number
+}
+
+interface Range {
+    start: Position
+    end: Position
+}
+
+interface Delta {
+    range: Range
+    replacement: string
+}
+
+interface Edit {
+    uri: string
+    revision: number
+    delta: Delta[]
+}
+
+interface Cursor {
+    uri: string
+    ranges: Range[]
+}
+
+interface CursorFromDaemon {
+    userid: string
+    name?: string
+    uri: string
+    ranges: Range[]
+}
+
+declare class Revision {
+    daemon: number
+    editor: number
+}
+
+interface Configuration {
+    cmd: string[]
+    rootMarkers: string[]
+}
+
+interface DocumentOTState {
+    revision: Revision
+    content: string[]
+}
+
+interface RemoteCursor {
+    name: string
+    uri: import("vscode").Uri
+    selection: import("vscode").DecorationOptions
+}


### PR DESCRIPTION
Adds a "Teamtype: Follow a user's cursor" command. Opens a quick pick with all active cursors. Pick one to follow their cursor in real time. Includes a "Stop following" option.

Also fixes a URI comparison bug—was comparing by reference instead of by value, so following always opened a new tab instead of reusing an existing one.