### PR TITLE
Add option `--always-remove-socket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 <!--
 SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
+SPDX-FileCopyrightText: 2026 axelmartensson <axel.martensson@hotmail.com>
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->
 
 # 0.9.2 (unreleased)
+
+Add option `--always-remove-socket` to always remove `.teamtype/socket` if it already exists on startup without asking for confirmation.
 
 Add a Nix Flake to the project so the repository can be run directly, used as a dependency, or just to supply a developer environment.
 

--- a/crates/teamtype/src/cli.rs
+++ b/crates/teamtype/src/cli.rs
@@ -49,6 +49,9 @@ pub struct ShareJoinFlags {
     /// or if `HOME` is not set in `/home/$USER/.cache/teamtype/`.
     #[arg(short, long)]
     pub temporary_directory: bool,
+    /// Always remove `.teamtype/socket` if it already exists on startup without asking for confirmation.
+    #[arg(long)]
+    pub always_remove_socket: bool,
 }
 
 #[derive(Subcommand)]

--- a/crates/teamtype/src/config.rs
+++ b/crates/teamtype/src/config.rs
@@ -30,6 +30,7 @@ const EMIT_JOIN_CODE_DEFAULT: bool = true;
 const EMIT_SECRET_ADDRESS_DEFAULT: bool = false;
 // TODO: Generate a random funny name.
 const USERNAME_FALLBACK: &str = "Anonymous";
+const ALWAYS_REMOVE_SOCKET_DEFAULT: bool = false;
 
 #[derive(Clone, Debug)]
 pub enum Peer {
@@ -37,6 +38,7 @@ pub enum Peer {
     JoinCode(String),
 }
 
+#[expect(clippy::struct_excessive_bools)]
 #[derive(Clone, Default, Debug)]
 #[must_use]
 pub struct AppConfig {
@@ -51,6 +53,7 @@ pub struct AppConfig {
     // Whether to sync version control directories like .git, .jj, ...
     pub sync_vcs: bool,
     pub username: Option<String>,
+    pub always_remove_socket: bool,
 }
 
 impl AppConfig {
@@ -121,6 +124,15 @@ impl AppConfig {
             }),
             sync_vcs: app_config_cli.sync_vcs,
             username: Some(username),
+            always_remove_socket: app_config_cli.always_remove_socket
+                || general_section.get("always_remove_socket").map_or(
+                    ALWAYS_REMOVE_SOCKET_DEFAULT,
+                    |ejc| {
+                        ejc.parse().expect(
+                            "Failed to parse config parameter `always_remove_socket` as bool",
+                        )
+                    },
+                ),
         }
     }
 

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
 // SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+// SPDX-FileCopyrightText: 2026 axelmartensson <axel.martensson@hotmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -965,11 +966,19 @@ impl Daemon {
 
         let base_dir = &app_config.base_dir;
 
+        let always_remove_socket = &app_config.always_remove_socket;
+
         // Start socket listener.
         let socket_path = base_dir
             .join(config::CONFIG_DIR)
             .join(config::DEFAULT_SOCKET_NAME);
-        editor::spawn_socket_listener(&socket_path, document_handle.clone(), prompt_bool)?;
+
+        editor::spawn_socket_listener(
+            &socket_path,
+            *always_remove_socket,
+            document_handle.clone(),
+            prompt_bool,
+        )?;
 
         // Start file watcher.
         spawn_file_watcher(&app_config, document_handle.clone());

--- a/crates/teamtype/src/editor.rs
+++ b/crates/teamtype/src/editor.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2024 zormit <nt4u@kpvn.de>
 // SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+// SPDX-FileCopyrightText: 2026 axelmartensson <axel.martensson@hotmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -98,6 +99,7 @@ pub(crate) fn strip_current_dir(path: &Path) -> PathBuf {
 /// Will panic if we fail to listen on the socket, or if we fail to accept an incoming connection.
 pub fn spawn_socket_listener(
     socket_path: &Path,
+    always_remove_socket: bool,
     document_handle: DocumentActorHandle,
     bool_prompter: &dyn Fn(&str) -> Result<bool>,
 ) -> Result<()> {
@@ -113,10 +115,11 @@ pub fn spawn_socket_listener(
         .expect("Failed to check existence of path")
     {
         let socket_path_display = socket_path.display();
-        let remove_socket = bool_prompter(&format!(
-            "Detected an existing socket '{socket_path_display}'. There might be a daemon running already for this directory, or the previous one crashed. Do you want to continue?"
-        ));
-        if remove_socket? {
+        let remove_socket = always_remove_socket
+            || bool_prompter(&format!(
+                "Detected an existing socket '{socket_path_display}'. There might be a daemon running already for this directory, or the previous one crashed. Do you want to continue?"
+            ))?;
+        if remove_socket {
             sandbox::remove_file(Path::new("/"), socket_path).expect("Could not remove socket");
         } else {
             bail!("Not continuing, make sure to stop all other daemons on this directory");

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -125,6 +125,7 @@ async fn parse_join_config(command: Commands, directory: PathBuf) -> Result<AppC
                 iroh_pkarr_relay,
                 sync_vcs,
                 username,
+                always_remove_socket,
                 ..
             },
         ..
@@ -141,6 +142,7 @@ async fn parse_join_config(command: Commands, directory: PathBuf) -> Result<AppC
             iroh_pkarr_relay,
             sync_vcs,
             username,
+            always_remove_socket,
         };
         let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli);
         app_config = app_config
@@ -164,6 +166,7 @@ fn parse_share_config(command: Commands, directory: PathBuf) -> AppConfig {
                 iroh_pkarr_relay,
                 sync_vcs,
                 username,
+                always_remove_socket,
                 ..
             },
         show_secret_address,
@@ -181,6 +184,7 @@ fn parse_share_config(command: Commands, directory: PathBuf) -> AppConfig {
             iroh_pkarr_relay,
             sync_vcs,
             username,
+            always_remove_socket,
         };
         let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli);
         // Because of the "share" subcommand, explicitly don't connect anywhere.


### PR DESCRIPTION
Add option `--always-remove-socket` to always remove `.teamtype/socket` if it already exists on startup without asking for confirmation.

**Self-review checklist**

- [X] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [X] I have manually tested and self-reviewed my changes.
- [X] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [X] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).


## Motivation
Always removing `.teamtype/socket` if it already exists on startup without asking for confirmation is useful when running the teamtype daemon non-interactively, e.g. when the teamtype daemon is run as a service.

The use-case is enabling the teamtype daemon service to start automatically without user input after a reboot.

The scenario is:

1. Daemon running -> `.teamtype/socket` exists
2. Hard reboot -> `.teamtype/socket` does not get cleaned 
   up, and still exists when the computer is started
3. Daemon starting ->
  - If `--always-remove-socket` is set: the user is not prompted, and the old socket is removed.
  - If `--always-remove-socket` is not set: the user is prompted, like before.

## Example that reproduces the issue

Running this (where we simulate the socket already existing 
by using `touch` to create an empty file):
```sh
set -e
TEAMTYPE_COMMAND=$(pwd)/target/debug/teamtype
TEMP_DIR=$(mktemp -d)
trap "rm -rf $TEMP_DIR" EXIT
cd $TEMP_DIR
mkdir --mode=700 .teamtype
touch .teamtype/socket
teamtype share
```

Results in the prompt:
```
Detected an existing socket '/tmp/tmp.ppw4rAdUZF/.teamtype/socket'. There might be a daemon running already for this directory, or the previous one crashed. Do you want to continue? (y/N): 
```

# Examples that show how this PR fixes the issue

Adding the `--always-remove-socket` option on the command line:
```sh
set -e
TEAMTYPE_COMMAND=$(pwd)/target/debug/teamtype
TEMP_DIR=$(mktemp -d)
trap "rm -rf $TEMP_DIR" EXIT
cd $TEMP_DIR
mkdir --mode=700 .teamtype
touch .teamtype/socket
$TEAMTYPE_COMMAND share --always-remove-socket
```

Results in a successful startup without a prompt

Same thing for the case where we add the option in the 
config file

```sh
set -e
TEAMTYPE_COMMAND=$(pwd)/target/debug/teamtype
TEMP_DIR=$(mktemp -d)
trap "rm -rf $TEMP_DIR" EXIT
cd $TEMP_DIR
mkdir --mode=700 .teamtype
touch .teamtype/socket
echo always_remove_socket=true > .teamtype/config
$TEAMTYPE_COMMAND share
```

Results in a successful startup without a prompt

