### PR TITLE
feat(daemon): Auto-detect whether existing socket is connected to daemon

### DIFF
--- a/crates/e2e-tests/tests/fuzzer.rs
+++ b/crates/e2e-tests/tests/fuzzer.rs
@@ -44,10 +44,6 @@ fn initialize_directory() -> (TempDir, PathBuf, PathBuf) {
     (dir, dir_path.to_path_buf(), file)
 }
 
-fn prompt_bool_dummy(_: &str) -> Result<bool> {
-    Ok(false)
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     let default_panic = std::panic::take_hook();
@@ -66,7 +62,7 @@ async fn main() -> Result<()> {
     // Set up the actors.
     let mut app_config = AppConfig::default();
     app_config.base_dir = dir1;
-    let daemon = Daemon::new(app_config, true, false, &prompt_bool_dummy).await?;
+    let daemon = Daemon::new(app_config, true, false).await?;
 
     // Wait until iroh's DNS discovery (hopefully) works.
     sleep(Duration::from_millis(1000)).await;
@@ -76,7 +72,7 @@ async fn main() -> Result<()> {
     let mut app_config2 = AppConfig::default();
     app_config2.base_dir = dir2;
     app_config2.peer = Some(config::Peer::SecretAddress(daemon.address.clone()));
-    let peer = Daemon::new(app_config2, false, false, &prompt_bool_dummy).await?;
+    let peer = Daemon::new(app_config2, false, false).await?;
 
     // Wait until file2 appears.
     while !file2.exists() {

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -953,12 +953,7 @@ pub struct Daemon {
 
 impl Daemon {
     // Launch the daemon. Optionally, connect to given peer.
-    pub async fn new(
-        app_config: AppConfig,
-        init: bool,
-        persist: bool,
-        prompt_bool: &(dyn Fn(&str) -> Result<bool> + Send + Sync),
-    ) -> Result<Self> {
+    pub async fn new(app_config: AppConfig, init: bool, persist: bool) -> Result<Self> {
         let is_host = app_config.is_host();
 
         let document_handle = DocumentActorHandle::new(&app_config, init, is_host, persist);
@@ -969,7 +964,7 @@ impl Daemon {
         let socket_path = base_dir
             .join(config::CONFIG_DIR)
             .join(config::DEFAULT_SOCKET_NAME);
-        editor::spawn_socket_listener(&socket_path, document_handle.clone(), prompt_bool)?;
+        editor::spawn_socket_listener(&socket_path, document_handle.clone())?;
 
         // Start file watcher.
         spawn_file_watcher(&app_config, document_handle.clone());

--- a/crates/teamtype/src/editor.rs
+++ b/crates/teamtype/src/editor.rs
@@ -6,7 +6,7 @@
 
 //! This module is all about daemon to editor communication.
 
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::{fs::PermissionsExt, net::UnixStream as StdUnixStream};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
@@ -99,7 +99,6 @@ pub(crate) fn strip_current_dir(path: &Path) -> PathBuf {
 pub fn spawn_socket_listener(
     socket_path: &Path,
     document_handle: DocumentActorHandle,
-    bool_prompter: &dyn Fn(&str) -> Result<bool>,
 ) -> Result<()> {
     // Make sure the parent directory of the socket is only accessible by the current user.
     if let Err(description) = is_user_readable_only(socket_path) {
@@ -112,14 +111,17 @@ pub fn spawn_socket_listener(
     if sandbox::exists(Path::new("/"), Path::new(&socket_path))
         .expect("Failed to check existence of path")
     {
-        let socket_path_display = socket_path.display();
-        let remove_socket = bool_prompter(&format!(
-            "Detected an existing socket '{socket_path_display}'. There might be a daemon running already for this directory, or the previous one crashed. Do you want to continue?"
-        ));
-        if remove_socket? {
-            sandbox::remove_file(Path::new("/"), socket_path).expect("Could not remove socket");
-        } else {
-            bail!("Not continuing, make sure to stop all other daemons on this directory");
+        // If there's an existing socket, try to connect to it as a client. If that fails, we assume
+        // there's no other daemon running and we can delete the socket.
+        match StdUnixStream::connect(strip_current_dir(socket_path)) {
+            Ok(_) => {
+                bail!(
+                    "Detected an existing daemon running for this directory. Rejecting to start another one."
+                );
+            }
+            Err(_) => {
+                sandbox::remove_file(Path::new("/"), socket_path).expect("Could not remove socket");
+            }
         }
     }
 

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -109,7 +109,7 @@ async fn run_daemon(app_config: AppConfig, init_doc: bool) -> Result<Daemon> {
     // Setup a new daemon from the derived config. Immediately join the handle because that's what
     // actually starts the local socket and any configured network connections. Return the result
     // so the calling context can determine when to terminate.
-    Daemon::new(app_config, init_doc, persist, &prompt_bool)
+    Daemon::new(app_config, init_doc, persist)
         .await
         .context("Failed to launch the daemon")
 }


### PR DESCRIPTION
If there's an existing socket, try to connect to it as a client. If that fails, we assume there's no other daemon runing and we can delete the socket.

Fixes #592.

**Self-review checklist**

- [ ] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md). -> skipping for now, to be discussed
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
