### PR TITLE
Notify user when attempting to remove defunct socket

### DIFF
--- a/crates/teamtype/src/editor.rs
+++ b/crates/teamtype/src/editor.rs
@@ -21,7 +21,7 @@ use tokio_util::{
     bytes::BytesMut,
     codec::{Decoder, Encoder, FramedRead, FramedWrite, LinesCodec},
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::daemon::{DocMessage, DocumentActorHandle};
 use crate::editor_protocol::{
@@ -120,6 +120,9 @@ pub fn spawn_socket_listener(
                 );
             }
             Err(_) => {
+                warn!(
+                    "An existing socket was found for this directory, but since the daemon seems to be defunct it is being removed."
+                );
                 sandbox::remove_file(Path::new("/"), socket_path).expect("Could not remove socket");
             }
         }

--- a/crates/teamtype/src/editor.rs
+++ b/crates/teamtype/src/editor.rs
@@ -113,19 +113,15 @@ pub fn spawn_socket_listener(
     {
         // If there's an existing socket, try to connect to it as a client. If that fails, we assume
         // there's no other daemon running and we can delete the socket.
-        match StdUnixStream::connect(strip_current_dir(socket_path)) {
-            Ok(_) => {
-                bail!(
-                    "Detected an existing daemon running for this directory. Rejecting to start another one."
-                );
-            }
-            Err(_) => {
-                warn!(
-                    "An existing socket was found for this directory, but since the daemon seems to be defunct it is being removed."
-                );
-                sandbox::remove_file(Path::new("/"), socket_path).expect("Could not remove socket");
-            }
+        if StdUnixStream::connect(strip_current_dir(socket_path)).is_ok() {
+            bail!(
+                "Detected an existing daemon running for this directory. Rejecting to start another one."
+            );
         }
+        warn!(
+            "An existing socket was found for this directory, but since the daemon seems to be defunct it is being removed."
+        );
+        sandbox::remove_file(Path::new("/"), socket_path).expect("Could not remove socket");
     }
 
     // The std library function used to create sockets requires a path shorter than SUN_LEN, but the


### PR DESCRIPTION
I probably should have thought of this when reviewing #598, but this is a perfect use case for logging. ~~The user doesn't normally need to see this, but when you are trying to debug where things are getting to it's helpful to have debug messages as each operation phase is launched.~~ The user may elect not to see this information, but the fact that a defunct socket was found at all suggests some previous failure mode they may not have understood or wish to investigate further.

**Self-review checklist**

- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) pattern, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md) for details how we use it in this project.
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).